### PR TITLE
Add support for unittests in build system

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -4,31 +4,60 @@ CXX ?= clang++
 STDCXX ?= c++17
 DBG_FLAGS ?= -Og -g
 OPT_FLAGS ?= -O3 -DNDEBUG
-CPP_FILES ?= $(shell find . -name '*.cpp' -not -name 'plugin.cpp' -not -name 'main.cpp')
-HPP_FILES ?= $(shell find . -name '*.hpp')
+CPP_FILES ?= $(shell find . -name '*.cpp' -not -name 'plugin.cpp' -not -name 'main.cpp' -not -path '*/tests/*')
+CPP_TEST_FILES ?= $(shell find tests/ -name '*.cpp')
+HPP_FILES ?= $(shell find -L . -name '*.hpp')
+# I need -L to follow symlinks in common/
+LDFLAGS := -ggdb $(LDFLAGS)
 
 # In the future, if compilation is slow, we can enable partial compilation of object files with
 #  $(OBJ_FILES:.o=.dbg.o) and  $(OBJ_FILES:.o=.opt.o)
 plugin.dbg.so: plugin.cpp $(CPP_FILES) $(HPP_FILES) Makefile
-	$(CXX) -ggdb -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(dbg_flags) -shared -fpic -o $@ plugin.cpp $(CPP_FILES) $(LDFLAGS)
+	$(CXX) -ggdb -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(DBG_FLAGS) -shared -fpic \
+	-o $@ plugin.cpp $(CPP_FILES) $(LDFLAGS)
 
 plugin.opt.so: plugin.cpp $(CPP_FILES) $(HPP_FILES) Makefile
-	$(CXX) -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(opt_flags)  -shared -fpic -o $@ plugin.cpp $(CPP_FILES) $(LDFLAGS)
+	$(CXX)       -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(OPT_FLAGS) -shared -fpic \
+	-o $@ plugin.cpp $(CPP_FILES) $(LDFLAGS)
 
 main.dbg.exe: main.cpp $(CPP_FILES) $(HPP_FILES) Makefile
-	$(CXX) -ggdb -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(dbg_flags) -o $@ main.cpp $(CPP_FILES) $(LDFLAGS)
+	$(CXX) -ggdb -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(DBG_FLAGS) \
+	-o $@ main.cpp $(CPP_FILES) $(LDFLAGS)
 
 main.opt.exe: main.cpp $(CPP_FILES) $(HPP_FILES) Makefile
-	$(CXX) -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(opt_flags) -o $@ main.cpp $(CPP_FILES) $(LDFLAGS)
+	$(CXX)        -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(OPT_FLAGS) \
+	-o $@ main.cpp $(CPP_FILES) $(LDFLAGS)
 
 %.dbg.o: %.cpp $(OTHER_DEPS) Makefile
-	$(CXX) -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(dbg_flags) -o $@ $<
+	$(CXX) -ggdb  -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(DBG_FLAGS) \
+	-o $@ $<
 
 %.opt.o: %.cpp $(OTHER_DEPS) Makefile
-	$(CXX) -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(opt_flags) -o $@ $<
+	$(CXX)        -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(OPT_FLAGS) \
+	-o $@ $<
+
+.PHONY: test/run test/gdb
+ifeq ($(CPP_TEST_FILES),)
+tests/run:
+tests/gdb:
+else
+tests/run: tests/test.exe
+	./tests/test.exe
+
+tests/gdb: tests/test.exe
+	gdb -q ./tests/test.exe -ex r
+
+tests/test.exe: $(CPP_TEST_FILES) $(CPP_FILES) $(HPP_FILES)
+	$(CXX) -ggdb -std=$(STDCXX) $(CFLAGS) $(CPPFLAGS) $(DBG_FLAGS) \
+	$(shell pkg-config --libs --cflags gtest_main) -fsanitize=address,undefined -o ./tests/test.exe \
+	$(CPP_TEST_FILES) $(CPP_FILES) $(LDFLAGS)
+endif
 
 .PHONY: clean
 clean:
 	touch _target && \
 	$(RM) _target *.so *.exe *.o
 # if *.so and *.o do not exist, rm will still work, because it still receives an operand (target)
+
+.PHONY: deepclean
+deepclean: clean

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -12,7 +12,8 @@ then
 		 git clang cmake libc++-dev libc++abi-dev \
 		 libeigen3-dev libboost-dev libboost-thread-dev libboost-system-dev libatlas-base-dev libsuitesparse-dev libblas-dev libglfw3-dev \
 		 glslang-tools libsdl2-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev glslang-tools libusb-dev libusb-1.0 libudev-dev libv4l-dev libhidapi-dev libglew-dev glew-utils libglfw3-dev \
-		 git build-essential libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev
+		 git build-essential libx11-xcb-dev libxkbcommon-dev libwayland-dev libxrandr-dev \
+		 libgtest-dev
 
 	old_pwd="${PWD}"
 	mkdir -p /tmp/ILLIXR_deps


### PR DESCRIPTION
I added support for unittests via [Google
Test](https://github.com/google/googletest)

I will upload an example and docs for doing this in the future

I also rolled minor tweaks to the build system:

- Correctly rebuilding when files in common are touched (changed the
  `find` targets)

- There was a problem with .PHONY rules that also have dependencies. I
  corrected this by removing the dependency, but that means I had to
  factor out usage of the automatic variable `$^` and `$<`.

- Added deepclean target to all components. This is useful when you
  want to clean all ILLIXR generated files, but not submodule libraries
  such as open_vins and libspatialaudio.