### PR TITLE
Make exit cleanly

### DIFF
--- a/common/extended_window.hpp
+++ b/common/extended_window.hpp
@@ -4,6 +4,7 @@
 #include <X11/Xlib.h>
 #include <GL/glx.h>
 #include <GL/glu.h>
+#include "phonebook.hpp"
 
 //GLX context magics
 #define GLX_CONTEXT_MAJOR_VERSION_ARB       0x2091

--- a/common/plugin.hpp
+++ b/common/plugin.hpp
@@ -23,13 +23,15 @@ namespace ILLIXR {
 
 		/**
 		 * @brief A method which Spindle calls when it starts the component.
-		 * 
-		 * This is necessary for stop-actions which have to replaced by the subclass. Destructors
-		 * would prepend instead of replace actions.
+		 *
+		 * This is necessary because the parent class might define some actions that need to be
+		 * taken prior to destructing the derived class. For example, threadloop must halt and join
+		 * the thread before the derived class can be safely destructed. However, the derived
+		 * class's destructor is called before its parent (threadloop), so threadloop doesn't get a
+		 * chance to join the thread before the derived class is destroyed, and the thread accesses
+		 * freed memory. Instead, we call plugin->stop manually before destrying anything.
 		 */
-		virtual void stop() {
-			metric_logger->log(std::make_unique<const component_stop_record>(id));
-		}
+		virtual void stop() { }
 
 		plugin(const std::string& name_, phonebook* pb_)
 			: name{name_}
@@ -39,7 +41,7 @@ namespace ILLIXR {
 			, id{gen_guid->get()}
 		{ }
 
-		virtual ~plugin() { stop(); }
+		virtual ~plugin() { }
 
 		std::string get_name() { return name; }
 

--- a/common/pose_prediction.hpp
+++ b/common/pose_prediction.hpp
@@ -10,4 +10,5 @@ public:
 	virtual bool fast_pose_reliable() const = 0;
 	virtual bool true_pose_reliable() const = 0;
 	virtual void set_offset(const Eigen::Quaternionf& orientation) = 0;
+	virtual ~pose_prediction() { }
 };

--- a/common/runtime.hpp
+++ b/common/runtime.hpp
@@ -3,20 +3,22 @@
 #include <vector>
 #include <memory>
 #include <GL/glx.h>
-#include "plugin.hpp"
 #include "extended_window.hpp"
 
 namespace ILLIXR {
+	class plugin;
 
-typedef plugin* (*plugin_factory) (phonebook*);
+	typedef plugin* (*plugin_factory) (phonebook*);
 
-class runtime {
-public:
-	virtual void load_so(std::string_view so) = 0;
-	virtual void load_plugin_factory(plugin_factory plugin) = 0;
-	virtual void wait() = 0;
-};
+	class runtime {
+	public:
+		virtual void load_so(std::string_view so) = 0;
+		virtual void load_plugin_factory(plugin_factory plugin) = 0;
+		virtual void wait() = 0;
+		virtual void stop() = 0;
+		virtual ~runtime() {}
+	};
 
-extern "C" runtime* runtime_factory(GLXContext appGLCtx);
+	extern "C" runtime* runtime_factory(GLXContext appGLCtx);
 
 }

--- a/common/switchboard.hpp
+++ b/common/switchboard.hpp
@@ -166,6 +166,8 @@ public:
 	}
 
 	virtual ~switchboard() { }
+
+	virtual void stop() = 0;
 };
 
 /* TODO: (usability) Do these HAVE to be smart pointers? If the

--- a/common/threadloop.hpp
+++ b/common/threadloop.hpp
@@ -24,6 +24,7 @@ public:
 	 * @brief Starts the thread.
 	 */
 	virtual void start() override {
+		plugin::start();
 		_m_thread = std::thread(std::bind(&threadloop::thread_main, this));
 	}
 
@@ -31,13 +32,20 @@ public:
 	 * @brief Stops the thread.
 	 */
 	virtual void stop() override {
-		_m_terminate.store(true);
-		_m_thread.join();
+		if (! _m_terminate.load()) {
+			_m_terminate.store(true);
+			_m_thread.join();
+			std::cerr << "Joined " << name << std::endl;
+			plugin::stop();
+		} else {
+			std::cerr << "You called stop() on this plugin twice." << std::endl;
+		}
 	}
 
 	virtual ~threadloop() override {
-		if (!should_terminate()) {
-			stop();
+		if (!_m_terminate.load()) {
+			std::cerr << "You didn't call stop() before destructing this plugin." << std::endl;
+			abort();
 		}
 	}
 

--- a/runtime/main.cpp
+++ b/runtime/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, const char * argv[]) {
 	// And timer
 	cancellable_sleep cs;
 	std::thread th{[&]{
-		cs.sleep(std::chrono::seconds(10));
+		cs.sleep(std::chrono::seconds(60));
 		r->stop();
 	}};
 

--- a/runtime/main.cpp
+++ b/runtime/main.cpp
@@ -1,10 +1,55 @@
+#include <signal.h>
 #include "runtime_impl.hpp"
 
+ILLIXR::runtime* r;
+
+static void signal_handler(int) {
+	if (r) {
+		r->stop();
+	}
+}
+
+class cancellable_sleep {
+public:
+	template <typename T, typename R>
+	bool sleep(std::chrono::duration<T, R> duration) {
+		auto wake_up_time = std::chrono::system_clock::now() + duration;
+		while (!_m_terminate.load() && std::chrono::system_clock::now() < wake_up_time) {
+			std::this_thread::sleep_for(std::chrono::milliseconds{100});
+		}
+		return _m_terminate.load();
+	}
+	void cancel() {
+		_m_terminate.store(true);
+	}
+private:
+	std::atomic<bool> _m_terminate {false};
+};
+
 int main(int argc, const char * argv[]) {
-	ILLIXR::runtime* r = ILLIXR::runtime_factory(nullptr);
+	r = ILLIXR::runtime_factory(nullptr);
+
 	for (int i = 1; i < argc; ++i) {
 		r->load_so(argv[i]);
 	}
-	r->wait();
+
+	// Two ways of shutting down:
+	// Ctrl+C
+	signal(SIGINT, signal_handler);
+
+	// And timer
+	cancellable_sleep cs;
+	std::thread th{[&]{
+		cs.sleep(std::chrono::seconds(10));
+		r->stop();
+	}};
+
+	r->wait(); // blocks until shutdown is r->stop()
+
+	// cancel our sleep, so we can join the other thread
+	cs.cancel();
+	th.join();
+
+	delete r;
 	return 0;
 }

--- a/runtime/switchboard_impl.hpp
+++ b/runtime/switchboard_impl.hpp
@@ -204,20 +204,25 @@ namespace ILLIXR {
 		switchboard_impl()
 		{
 			for (size_t i = 0; i < MAX_THREADS; ++i) {
-				_m_threads.push_back(std::thread{[this]() {
+				_m_threads.push_back(std::thread{[i, this]() {
+					;
+					std::cout << "thread," << std::this_thread::get_id() << ",switchboard worker," << i << std::endl;
 					this->check_queues();
 				}});
 			}
 		}
 
-		virtual void stop() {
-			_m_terminate.store(true);
-			for (std::thread& thread : _m_threads) {
-				thread.join();
+		virtual void stop() override {
+			if (!_m_terminate.load()) {
+				_m_terminate.store(true);
+				for (std::thread& thread : _m_threads) {
+					thread.join();
+				}
 			}
 		}
 
-		virtual ~switchboard_impl() {
+		virtual ~switchboard_impl() override {
+			stop();
 		}
 
 	private:


### PR DESCRIPTION
Note to reviewers:
- Verify:
  - In `runtime/main.cpp:main`, either `cancellable_sleep` xor `signal_handler` will call `runtime_impl::stop`.
  - `runtime_impl::stop`, we call `switchboard::stop` and each plugin's `plugin::stop`.
  - `switchboard::stop` stops the switchboard threads.
  - Because `plugin::stop` is virtual, the call could go to `plugin` or to any child of `plugin`.
    - `threadloop` is a child of `plugin`, so it goes to `threadloop::stop`, which stops the plugin's individual thread, and then goes to `plugin::stop`.
    - There are no other children of `plugin`.
  - In cases like `zed`, where it has resources to clean up, it would override `plugin::stop` or `threadloop::stop`, clean up resources, and then call the thing it overrode.
- Test:
  - Drop down the delay in `main.cpp`.
  - Run `./runner.sh configs/native.yaml`.
  - It should exit without an error message.
  - `echo $?` should return 0.