### PR TITLE
Download EuRoC in install_deps

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -88,11 +88,7 @@ then
 	fi
 
 	if [ ! -d "data1" ] && y_or_n "Next: Download Vicon Room 1 Medium SLAM dataset"; then
-		curl -o data.zip \
-		"http://robotics.ethz.ch/~asl-datasets/ijrr_euroc_mav_dataset/vicon_room1/V1_02_medium/V1_02_medium.zip" && \
-		unzip data.zip && \
-		rm -rf __MACOSX data1 && \
-		mv mav0 data1
+		. ./scripts/install_euroc.sh
 	fi
 
 	if ! which conda 2> /dev/null; then

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -124,6 +124,14 @@ then
 		sudo make -C "${temp_dir}/OpenXR-SDK/build" "-j$(nproc)" install
 	fi
 
+	if [ ! -d "data1" ] && y_or_n "Next: Download Vicon Room 1 Medium SLAM dataset"; then
+		curl -o data.zip \
+		"http://robotics.ethz.ch/~asl-datasets/ijrr_euroc_mav_dataset/vicon_room1/V1_02_medium/V1_02_medium.zip" && \
+		unzip data.zip && \
+		rm -rf __MACOSX data1 && \
+		mv mav0 data1
+	fi
+
 	if ! which conda 2> /dev/null; then
 		if [ ! -d "$HOME/miniconda3" ]; then
 			if y_or_n "Next: Install Conda"; then

--- a/scripts/install_euroc.sh
+++ b/scripts/install_euroc.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl -o data.zip \
+"http://robotics.ethz.ch/~asl-datasets/ijrr_euroc_mav_dataset/vicon_room1/V1_02_medium/V1_02_medium.zip" && \
+unzip data.zip && \
+rm -rf __MACOSX data1 && \
+mv mav0 data1


### PR DESCRIPTION
Previously, our makefile would download Vicon Room 1 Medium automatically if detected that it didn't exist. This is not done at the moment, and should be. Otherwise, the user would have to do it themselves, which is undesirable and causes an error the first time they try to run ILLIXR.
`install_deps.sh` is probably a better place to do this than `runner` since the dataset is a dependency of `offline_imu_cam`.