### PR TITLE
Fix Monado build with runner

### DIFF
--- a/configs/monado.yaml
+++ b/configs/monado.yaml
@@ -15,7 +15,8 @@ loader:
   name: monado
   monado:
     path: ../monado_integration
-    config: {}
+    config:
+      ILLIXR_PATH: ../../ILLIXR
   openxr_app:
     path: ../Monado_OpenXR_Simple_Example
     config: {}

--- a/configs/monado.yaml
+++ b/configs/monado.yaml
@@ -3,9 +3,9 @@ plugins:
   - path: offline_imu_cam/
   - path: open_vins/
   - path: pose_prediction/
-  - path: gldemo/
+  # - path: gldemo/
   - path: timewarp_gl/
-  - path: debugview/
+  # - path: debugview/
   - path: audio_pipeline/
   # - path: holgoram/
   # - path: zed/
@@ -20,4 +20,4 @@ loader:
   openxr_app:
     path: ../Monado_OpenXR_Simple_Example
     config: {}
-profile: dbg
+profile: opt

--- a/runner/runner/main.py
+++ b/runner/runner/main.py
@@ -265,7 +265,7 @@ async def load_monado(config: Dict[str, Any]) -> None:
         check=True,
         env=dict(
             XR_RUNTIME_JSON=str(monado_path / "build" / "openxr_monado-dev.json"),
-            ILLIXR_PATH=str(runtime_path),
+            ILLIXR_PATH=str(runtime_path / "runtime" / f"plugin.{profile}.so"),
             ILLIXR_COMP=":".join(map(str, plugin_paths)),
             ILLIXR_DATA=config["data"],
             **os.environ,


### PR DESCRIPTION
Building Monado with the runner (command: `./runner.sh configs/monado.yaml`) throws: 

`monado_integration/src/xrt/state_trackers/prober/p_prober.c:803:13: error: 'struct prober_device' has no member named 'illixr'
  return pdev->illixr.path;`