### PR TITLE
ILLIXR-Monado doesn't work on a fresh 20.04 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV opt_dir /opt/ILLIXR
 RUN mkdir -p ${temp_dir}
 RUN mkdir -p ${opt_dir}
 
-RUN apt update && apt install -y sudo apt-transport-https
+RUN apt update && apt install -y sudo
 
 COPY ./scripts/install_apt_deps.sh $HOME/scripts/install_apt_deps.sh
 RUN ./scripts/install_apt_deps.sh

--- a/scripts/install_apt_deps.sh
+++ b/scripts/install_apt_deps.sh
@@ -11,6 +11,6 @@ sudo apt-get install -y \
 	 libsqlite3-dev libeigen3-dev libboost-all-dev libatlas-base-dev libsuitesparse-dev libblas-dev \
 	 glslang-tools libsdl2-dev libglu1-mesa-dev mesa-common-dev freeglut3-dev libglew-dev glew-utils libglfw3-dev \
 	 libusb-dev libusb-1.0 libudev-dev libv4l-dev libhidapi-dev \
-	 build-essential libx11-xcb-dev libxcb-glx0-dev libxkbcommon-dev libwayland-dev libxrandr-dev \
+	 build-essential libx11-xcb-dev libxcb-glx0-dev libxcb-randr0-dev libxrandr-dev libxkbcommon-dev libwayland-dev \
 	 libgtest-dev pkg-config libgtk2.0-dev wget
 


### PR DESCRIPTION
gldemo runs fine but Monado doesn't because it can't find `xcb`.