### PR TITLE
Add badges/status icons to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ILLIXR
 
+![Tests](https://github.com/ILLIXR/ILLIXR/workflows/illixr-tests-master/badge.svg)
+
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/ILLIXR/community)
+
 <a href="https://www.youtube.com/watch?v=5GXsUP9_34U"><img alt="ILLIXR Simple Demo" src="https://img.youtube.com/vi/5GXsUP9_34U/0.jpg" style="width: 480px"></a>
 
 Illinois Extended Reality testbed or ILLIXR (pronounced like elixir) is the first open-source full-system Extended Reality (XR) testbed. It contains standalone state-of-the-art components representative of a generic XR workflow, as well as a runtime framework that integrates these components into an XR system. ILLIXR's runtime integration framework is modular, extensible, and [OpenXR](https://www.khronos.org/openxr)-compatible.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ILLIXR
 
-![Tests](https://github.com/ILLIXR/ILLIXR/workflows/illixr-tests-master/badge.svg)
-
+[![NCSA licensed](https://img.shields.io/badge/license-NCSA-blue.svg)](LICENSE.md)
+[![CI](https://github.com/ILLIXR/ILLIXR/workflows/illixr-tests-master/badge.svg)](https://github.com/ILLIXR/ILLIXR/actions)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/ILLIXR/community)
 
 <a href="https://www.youtube.com/watch?v=5GXsUP9_34U"><img alt="ILLIXR Simple Demo" src="https://img.youtube.com/vi/5GXsUP9_34U/0.jpg" style="width: 480px"></a>


### PR DESCRIPTION
As we have a gitter and CI set up, we can add some badges to help inform new users of the state of the repository.

We can add a GitHub Actions badge by embedding

<img src=https://github.com/ILLIXR/ILLIXR/workflows/illixr-tests-master/badge.svg>

on our README. This will pull the most recent CI status from our `illixr-tests-master` CI action.

We can also embed a nice Gitter badge like so:

[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/ILLIXR/community)

Helps new users know that we are active on Gitter.

![image](https://user-images.githubusercontent.com/5544935/93837239-f8319580-fc4a-11ea-9cfd-6245f9fe01e9.png)

