### PR TITLE
Issue 182: Build Kimera dependencies in opt

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
       # Performs the docker build and pulls the cache from either the branch name tag or from latest.
       # The latest tag is what is on master so it will use that cache the first time this branch runs
       - name: Build Docker Image
-        run: docker build --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
+        run: docker build --build-args JOBS="$(nproc)" --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
 
       - name: Push Docker Image
         run: docker push ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
       # Performs the docker build and pulls the cache from either the branch name tag or from latest.
       # The latest tag is what is on master so it will use that cache the first time this branch runs
       - name: Build Docker Image
-        run: docker build --build-args JOBS="$(nproc)" --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
+        run: docker build --build-arg JOBS="$(nproc)" --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
 
       - name: Push Docker Image
         run: docker push ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
       # Performs the docker build and pulls the cache from either the branch name tag or from latest.
       # The latest tag is what is on master so it will use that cache the first time this branch runs
       - name: Build Docker Image
-        run: docker build --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
+        run: docker build --build-args JOBS="$(nproc)" --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
 
       - if: ${{ env.ghcr_token }}
         name: Push Docker Image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
       # Performs the docker build and pulls the cache from either the branch name tag or from latest.
       # The latest tag is what is on master so it will use that cache the first time this branch runs
       - name: Build Docker Image
-        run: docker build --build-args JOBS="$(nproc)" --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
+        run: docker build --build-arg JOBS="$(nproc)" --cache-from ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }},ghcr.io/illixr/illixr-tests:latest . -t ghcr.io/illixr/illixr-tests:${{ steps.extract_branch.outputs.branch }}
 
       - if: ${{ env.ghcr_token }}
         name: Push Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CXX=clang++-10
 ENV temp_dir /tmp/ILLIXR
 ENV opt_dir /opt/ILLIXR
 
-RUN export illixr_nproc=$(($(nproc) - 1))
+RUN export illixr_nproc=$(($(nproc) / 2))
 RUN mkdir -p ${temp_dir}
 RUN mkdir -p ${opt_dir}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV CXX=clang++-10
 ENV temp_dir /tmp/ILLIXR
 ENV opt_dir /opt/ILLIXR
 
+RUN export illixr_nproc=$(nproc)
 RUN mkdir -p ${temp_dir}
 RUN mkdir -p ${opt_dir}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CXX=clang++-10
 ENV temp_dir /tmp/ILLIXR
 ENV opt_dir /opt/ILLIXR
 
-RUN export illixr_nproc=$(nproc)
+RUN export illixr_nproc=$(($(nproc) - 1))
 RUN mkdir -p ${temp_dir}
 RUN mkdir -p ${opt_dir}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM ubuntu:18.04
 
+ARG JOBS=1
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Moscow
 ENV CC=clang-10
 ENV CXX=clang++-10
 ENV temp_dir /tmp/ILLIXR
 ENV opt_dir /opt/ILLIXR
+ENV illixr_nproc ${JOBS}
 
-#RUN export illixr_nproc=$(($(nproc) / 2))
-RUN export illixr_nproc=1
 RUN mkdir -p ${temp_dir}
 RUN mkdir -p ${opt_dir}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV CXX=clang++-10
 ENV temp_dir /tmp/ILLIXR
 ENV opt_dir /opt/ILLIXR
 
-RUN export illixr_nproc=$(($(nproc) / 2))
+#RUN export illixr_nproc=$(($(nproc) / 2))
+RUN export illixr_nproc=1
 RUN mkdir -p ${temp_dir}
 RUN mkdir -p ${opt_dir}
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -46,6 +46,9 @@ function y_or_n() {
 
 if [ "${ID_LIKE}" = debian ] || [ "${ID}" = debian ]
 then
+	# Set nproc to either 1 or half the available cores
+	illixr_nproc=$(python3 -c 'import multiprocessing; print( max(multiprocessing.cpu_count() // 2, 1))')
+
 	# For system-wide installs that are not possible via apt
 	temp_dir=/tmp/ILLIXR_deps
 	mkdir -p "${temp_dir}"

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -10,15 +10,38 @@ set -e
 cd "$(dirname "${0}")"
 
 ### Parse args ###
-
+show_help=0
+exit_code=
 assume_yes=
+JOBS=1
 while [[ "$#" -gt 0 ]]; do
     case "${1}" in
         -y|--yes) assume_yes=true ;;
-        *) echo "Unknown parameter passed: ${1}"; exit 1 ;;
+		-h|--help)
+			show_help=1
+			;;
+		-j|--jobs)
+			if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
+				JOBS=$2
+				shift
+			else
+				echo "Error: Argument for number of jobs is missing"
+				show_help=1
+				exit_code=1
+			fi
+			;;
+        *) 	echo "Error: Unknown parameter passed: ${1}"; show_help=1; exit_code=1 ;;
     esac
     shift
 done
+
+if  [[ "$show_help" -eq 1 ]]; then
+	echo "ILLIXR install_deps:"
+	echo "    -y/--yes - yes to all dependencies"
+	echo "    -j/--jobs - number of jobs/cores/threads for make to use"
+	echo "    -h/--help - help info for install_deps"
+	exit $exit_code
+fi
 
 ### Get OS ###
 
@@ -47,7 +70,7 @@ function y_or_n() {
 if [ "${ID_LIKE}" = debian ] || [ "${ID}" = debian ]
 then
 	# Set nproc to either 1 or half the available cores
-	illixr_nproc=$(python3 -c 'import multiprocessing; print( max(multiprocessing.cpu_count() // 2, 1))')
+	illixr_nproc=$JOBS
 
 	# For system-wide installs that are not possible via apt
 	temp_dir=/tmp/ILLIXR_deps

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -24,14 +24,15 @@ while [[ "$#" -gt 0 ]]; do
 			exit_code=1
 			;;
 		-j|--jobs)
+			# Checks if the number of jobs is given and not negative
 			if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
 				illixr_nproc=$2
-				shift
 			else
-				echo "Error: Argument for number of jobs is missing"
+				echo "Error: Argument for number of jobs is missing or negative"
 				show_help=1
 				exit_code=1
 			fi
+			shift
 			;;
         *) 	echo "Error: Unknown parameter passed: ${1}"; show_help=1; exit_code=1 ;;
     esac

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -91,19 +91,19 @@ then
 		. ./scripts/install_openxr.sh
 	fi
 
-	if [ ! -d "${temp_dir}/gtsam" ] && y_or_n "Next: Install gtsam from source"; then
+	if [ ! -d "${opt_dir}/gtsam" ] && y_or_n "Next: Install gtsam from source"; then
 		. ./scripts/install_gtsam.sh
 	fi
 
-	if [ ! -d "${temp_dir}/opengv" ] && y_or_n "Next: Install opengv from source"; then
+	if [ ! -d "${opt_dir}/opengv" ] && y_or_n "Next: Install opengv from source"; then
 		. ./scripts/install_opengv.sh
 	fi
 
-	if [ ! -d "${temp_dir}/DBoW2" ] && y_or_n "Next: Install DBoW2 from source"; then
+	if [ ! -d "${opt_dir}/DBoW2" ] && y_or_n "Next: Install DBoW2 from source"; then
 		. ./scripts/install_dbow2.sh
 	fi
 
-	if [ ! -d "${temp_dir}/Kimera-RPGO" ] && y_or_n "Next: Install Kimera-RPGO from source"; then
+	if [ ! -d "${opt_dir}/Kimera-RPGO" ] && y_or_n "Next: Install Kimera-RPGO from source"; then
 		. ./scripts/install_kimera_rpgo.sh
 	fi
 

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -13,16 +13,19 @@ cd "$(dirname "${0}")"
 show_help=0
 exit_code=
 assume_yes=
-JOBS=1
+
+# Set nproc to either 1 or half the available cores
+illixr_nproc=1
 while [[ "$#" -gt 0 ]]; do
     case "${1}" in
         -y|--yes) assume_yes=true ;;
 		-h|--help)
 			show_help=1
+			exit_code=1
 			;;
 		-j|--jobs)
 			if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-				JOBS=$2
+				illixr_nproc=$2
 				shift
 			else
 				echo "Error: Argument for number of jobs is missing"
@@ -69,9 +72,6 @@ function y_or_n() {
 
 if [ "${ID_LIKE}" = debian ] || [ "${ID}" = debian ]
 then
-	# Set nproc to either 1 or half the available cores
-	illixr_nproc=$JOBS
-
 	# For system-wide installs that are not possible via apt
 	temp_dir=/tmp/ILLIXR_deps
 	mkdir -p "${temp_dir}"

--- a/scripts/install_dbow2.sh
+++ b/scripts/install_dbow2.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-git clone https://github.com/dorian3d/DBoW2.git "${temp_dir}/DBoW2"
+git clone https://github.com/dorian3d/DBoW2.git "${opt_dir}/DBoW2"
 
 cmake \
-	-S "${temp_dir}/DBoW2" \
-	-B "${temp_dir}/DBoW2/build"
+	-S "${opt_dir}/DBoW2" \
+	-B "${opt_dir}/DBoW2/build"
 
-sudo make -C "${temp_dir}/DBoW2/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/DBoW2/build" "-j$(nproc)" install

--- a/scripts/install_dbow2.sh
+++ b/scripts/install_dbow2.sh
@@ -6,4 +6,4 @@ cmake \
 	-S "${opt_dir}/DBoW2" \
 	-B "${opt_dir}/DBoW2/build"
 
-sudo make -C "${opt_dir}/DBoW2/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/DBoW2/build" "-j${illixr_nproc}" install

--- a/scripts/install_gtest.sh
+++ b/scripts/install_gtest.sh
@@ -2,4 +2,4 @@
 
 git clone https://github.com/google/googletest --branch release-1.10.0 "${opt_dir}/googletest"
 cmake -S "${opt_dir}/googletest" -B "${opt_dir}/googletest/build"
-make -C "${opt_dir}/googletest/build" "-j$(nproc)"
+make -C "${opt_dir}/googletest/build" "-j${illixr_nproc}"

--- a/scripts/install_gtsam.sh
+++ b/scripts/install_gtsam.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-git clone --branch kimera-gtsam https://github.com/ILLIXR/gtsam.git "${temp_dir}/gtsam"
+git clone --branch kimera-gtsam https://github.com/ILLIXR/gtsam.git "${opt_dir}/gtsam"
 
 cmake \
-	-S "${temp_dir}/gtsam" \
-	-B "${temp_dir}/gtsam/build" \
+	-S "${opt_dir}/gtsam" \
+	-B "${opt_dir}/gtsam/build" \
 	-D CMAKE_INSTALL_PREFIX=/usr/local \
 	-D GTSAM_WITH_TBB=OFF \
 	-D GTSAM_USE_SYSTEM_EIGEN=OFF \
 	-D GTSAM_POSE3_EXPMAP=ON \
 	-D GTSAM_ROT3_EXPMAP=ON
-sudo make -C "${temp_dir}/gtsam/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/gtsam/build" "-j$(nproc)" install

--- a/scripts/install_gtsam.sh
+++ b/scripts/install_gtsam.sh
@@ -10,4 +10,4 @@ cmake \
 	-D GTSAM_USE_SYSTEM_EIGEN=OFF \
 	-D GTSAM_POSE3_EXPMAP=ON \
 	-D GTSAM_ROT3_EXPMAP=ON
-sudo make -C "${opt_dir}/gtsam/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/gtsam/build" "-j${illixr_nproc}" install

--- a/scripts/install_kimera_rpgo.sh
+++ b/scripts/install_kimera_rpgo.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-git clone https://github.com/MIT-SPARK/Kimera-RPGO.git "${temp_dir}/Kimera-RPGO"
+git clone https://github.com/MIT-SPARK/Kimera-RPGO.git "${opt_dir}/Kimera-RPGO"
 
 cmake \
-	-S "${temp_dir}/Kimera-RPGO" \
-	-B "${temp_dir}/Kimera-RPGO/build"
+	-S "${opt_dir}/Kimera-RPGO" \
+	-B "${opt_dir}/Kimera-RPGO/build"
 
-sudo make -C "${temp_dir}/Kimera-RPGO/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/Kimera-RPGO/build" "-j$(nproc)" install

--- a/scripts/install_kimera_rpgo.sh
+++ b/scripts/install_kimera_rpgo.sh
@@ -6,4 +6,4 @@ cmake \
 	-S "${opt_dir}/Kimera-RPGO" \
 	-B "${opt_dir}/Kimera-RPGO/build"
 
-sudo make -C "${opt_dir}/Kimera-RPGO/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/Kimera-RPGO/build" "-j${illixr_nproc}" install

--- a/scripts/install_opencv.sh
+++ b/scripts/install_opencv.sh
@@ -26,7 +26,7 @@ cmake \
 	    -D WITH_VTK=ON \
 	    -D OPENCV_EXTRA_MODULES_PATH="${temp_dir}/opencv_contrib/modules" \
 	    ${extra_cmake_args}
-sudo make -C "${temp_dir}/opencv/build" "-j$(nproc)" install
+sudo make -C "${temp_dir}/opencv/build" "-j${illixr_nproc}" install
 
 # Remove temp cmake files
 rm -f a.out cmake_hdf5_test.o

--- a/scripts/install_opengv.sh
+++ b/scripts/install_opengv.sh
@@ -8,4 +8,4 @@ cmake \
     -D EIGEN_INCLUDE_DIR="${opt_dir}/gtsam/gtsam/3rdparty/Eigen" \
     -D EIGEN_INCLUDE_DIRS="${opt_dir}/gtsam/gtsam/3rdparty/Eigen"
 
-sudo make -C "${opt_dir}/opengv/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/opengv/build" "-j${illixr_nproc}" install

--- a/scripts/install_opengv.sh
+++ b/scripts/install_opengv.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-git clone https://github.com/laurentkneip/opengv.git "${temp_dir}/opengv"
+git clone https://github.com/laurentkneip/opengv.git "${opt_dir}/opengv"
 
 cmake \
-	-S "${temp_dir}/opengv" \
-	-B "${temp_dir}/opengv/build" \
-    -D EIGEN_INCLUDE_DIR="${temp_dir}/gtsam/gtsam/3rdparty/Eigen" \
-    -D EIGEN_INCLUDE_DIRS="${temp_dir}/gtsam/gtsam/3rdparty/Eigen"
+	-S "${opt_dir}/opengv" \
+	-B "${opt_dir}/opengv/build" \
+    -D EIGEN_INCLUDE_DIR="${opt_dir}/gtsam/gtsam/3rdparty/Eigen" \
+    -D EIGEN_INCLUDE_DIRS="${opt_dir}/gtsam/gtsam/3rdparty/Eigen"
 
-sudo make -C "${temp_dir}/opengv/build" "-j$(nproc)" install
+sudo make -C "${opt_dir}/opengv/build" "-j$(nproc)" install

--- a/scripts/install_openxr.sh
+++ b/scripts/install_openxr.sh
@@ -2,4 +2,4 @@
 
 git clone https://github.com/KhronosGroup/OpenXR-SDK.git "${temp_dir}/OpenXR-SDK"
 cmake -S "${temp_dir}/OpenXR-SDK" -B "${temp_dir}/OpenXR-SDK/build"
-sudo make -C "${temp_dir}/OpenXR-SDK/build" "-j$(nproc)" install
+sudo make -C "${temp_dir}/OpenXR-SDK/build" "-j${illixr_nproc}" install

--- a/scripts/install_qemu.sh
+++ b/scripts/install_qemu.sh
@@ -8,7 +8,7 @@ cd "${opt_dir}/qemu/build"
 ../configure --enable-sdl --enable-opengl --enable-virglrenderer --enable-system --enable-modules --audio-drv-list=pa --target-list=x86_64-softmmu --enable-kvm
 
 # Build
-make -j$(nproc --ignore=1)
+make "-j${illixr_nproc}"
 
 # Qemu is located at:
 # ${opt_dir}/qemu/build/x86_64-softmmu/qemu-system-x86_64

--- a/scripts/install_vulkan_headers.sh
+++ b/scripts/install_vulkan_headers.sh
@@ -5,4 +5,4 @@ cmake \
 	-S "${temp_dir}/Vulkan-Headers" \
 	-B "${temp_dir}/Vulkan-Headers/build" \
 	-D CMAKE_INSTALL_PREFIX=install
-sudo make -C "${temp_dir}/Vulkan-Headers/build" "-j$(nproc)" install
+sudo make -C "${temp_dir}/Vulkan-Headers/build" "-j${illixr_nproc}" install


### PR DESCRIPTION
We now build kimera dependencies in opt as explained in #182. Also updated the scripts to only use half the cores, so we don't run out of memory on either virtual machines or under powered machines.