### PR TITLE
Fix runner for monado

### DIFF
--- a/configs/rt_slam_plugins.yaml
+++ b/configs/rt_slam_plugins.yaml
@@ -5,5 +5,9 @@ plugin_group:
     path:
       git_repo: https://github.com/ILLIXR/Kimera-VIO
       version: 6ea99d33fc2435a8c514049416dcb2f8a0e31692
+  #- name: OpenVINS
+  #  path:
+  #    git_repo: https://github.com/ILLIXR/open_vins.git
+  #    version: c6a4f8835851d21f87add38260e73df63c6354a1
   - path: gtsam_integrator/
   - path: pose_prediction/

--- a/runner/runner/main.py
+++ b/runner/runner/main.py
@@ -190,6 +190,7 @@ def load_monado(config: Mapping[str, Any]) -> None:
         openxr_app_path / "build",
         dict(CMAKE_BUILD_TYPE=cmake_profile, **openxr_app_config),
     )
+    build_runtime(config, "so")
     plugin_paths = threading_map(
         lambda plugin_config: build_one_plugin(config, plugin_config),
         [


### PR DESCRIPTION
- The runner was not building a shared object plugin for the runtime due to a missed line. 
- I have added OpenVINS to SLAM config file to allow for more accessibility (digging through to find the correct version would be a pain for most people). 