### PR TITLE
Clear errno after hazard and check errno for faults

### DIFF
--- a/common/extended_window.hpp
+++ b/common/extended_window.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cerrno>
 #include <X11/X.h>
 #include <X11/Xlib.h>
 #include <GL/glx.h>

--- a/common/extended_window.hpp
+++ b/common/extended_window.hpp
@@ -30,6 +30,13 @@ namespace ILLIXR{
             if (!dpy) {
                 printf("\n\tcannot connect to X server\n\n");
                 exit(1);
+            } else {
+				// Apparently, XOpenDisplay's _true_ error indication is whether dpy is nullptr.
+				// https://cboard.cprogramming.com/linux-programming/119957-xlib-perversity.html
+				// if (errno != 0) {
+				// 	std::cerr << "XOpenDisplay succeeded, but errno = " << errno << "; This is benign, so I'm clearing it now.\n";
+				// }
+				errno = 0;
             }
 
             Window root = DefaultRootWindow(dpy);

--- a/runtime/runtime_impl.hpp
+++ b/runtime/runtime_impl.hpp
@@ -73,7 +73,18 @@ public:
 			std::cerr << "You didn't call stop() before destructing this plugin." << std::endl;
 			abort();
 		}
-		assert(errno == 0);
+		assert(errno == 0 && "errno was set during run. Maybe spurious?");
+		/*
+		  Note that this assertion can have false positives AND false negatives!
+		  - False positive because the contract of some functions specifies that errno is only meaningful if the return code was an error [1].
+		    - We will try to mitigate this by clearing errno on success in ILLIXR.
+		  - False negative if some intervening call clears errno.
+		    - We will try to mitigate this by checking for errors immediately after a call.
+
+		  Despite these mitigations, the best way to catch errors is to check errno immediately after a calling function.
+
+		  [1] https://cboard.cprogramming.com/linux-programming/119957-xlib-perversity.html
+		 */
 	}
 
 private:

--- a/runtime/runtime_impl.hpp
+++ b/runtime/runtime_impl.hpp
@@ -1,4 +1,5 @@
 #include <thread>
+#include <cerrno>
 #include <chrono>
 #include "common/runtime.hpp"
 #include "common/extended_window.hpp"
@@ -71,6 +72,7 @@ public:
 			std::cerr << "You didn't call stop() before destructing this plugin." << std::endl;
 			abort();
 		}
+		assert(errno == 0);
 	}
 
 private:

--- a/runtime/runtime_impl.hpp
+++ b/runtime/runtime_impl.hpp
@@ -1,4 +1,5 @@
 #include <thread>
+#include <cassert>
 #include <cerrno>
 #include <chrono>
 #include "common/runtime.hpp"


### PR DESCRIPTION
- Apparently, `XOpenDisplay` can set `errno` even if there is no error ([source](https://cboard.cprogramming.com/linux-programming/119957-xlib-perversity.html)). The true indication of error is whether its return is non-null. This theoretical possibility was actually happening on two systems I tested with. Therefore, we need to clear `errno`.
- To catch this in the future, I will `assert(errno == 0)`. This is not meant to be a "definitive" check. It could be set despite no error (as in the previous case), and it could be unset despite an error (if some intermediate call clears it). For a definitive check, we would need to check every call that could set `errno`. For now, I am satisfied with "partial" `errno` checking for now.


Fixes #212.