### PR TITLE
Add stoplight to synchronize thread starts/stops

### DIFF
--- a/common/plugin.hpp
+++ b/common/plugin.hpp
@@ -27,8 +27,9 @@ namespace ILLIXR {
 		/**
 		 * @brief A method which Spindle calls when it starts the component.
 		 *
-		 * This is necessary because a constructor can't call derived virtual methods (due to
-		 * structure of C++).
+		 * This is necessary because a constructor can't call derived virtual
+		 * methods (due to structure of C++). See `threadloop` for an example of
+		 * this use-case.
 		 */
 		virtual void start() {
 			record_logger_->log(record{__plugin_start_header, {

--- a/common/plugin.hpp
+++ b/common/plugin.hpp
@@ -26,6 +26,9 @@ namespace ILLIXR {
 
 		/**
 		 * @brief A method which Spindle calls when it starts the component.
+		 *
+		 * This is necessary because a constructor can't call derived virtual methods (due to
+		 * structure of C++).
 		 */
 		virtual void start() {
 			record_logger_->log(record{__plugin_start_header, {
@@ -35,7 +38,7 @@ namespace ILLIXR {
 		}
 
 		/**
-		 * @brief A method which Spindle calls when it starts the component.
+		 * @brief A method which Spindle calls when it stops the component.
 		 *
 		 * This is necessary because the parent class might define some actions that need to be
 		 * taken prior to destructing the derived class. For example, threadloop must halt and join

--- a/common/runtime.hpp
+++ b/common/runtime.hpp
@@ -15,8 +15,18 @@ namespace ILLIXR {
 		virtual void load_so(const std::vector<std::string>& so) = 0;
 		virtual void load_so(const std::string_view so) = 0;
 		virtual void load_plugin_factory(plugin_factory plugin) = 0;
+
+		/**
+		 * Returns when the runtime is completely stopped.
+		 */
 		virtual void wait() = 0;
+
+		/**
+		 * Requests that the runtime is completely stopped.
+		 * Clients must call this before deleting the runtime.
+		 */
 		virtual void stop() = 0;
+
 		virtual ~runtime() {}
 	};
 

--- a/common/runtime.hpp
+++ b/common/runtime.hpp
@@ -27,7 +27,8 @@ namespace ILLIXR {
 		 */
 		virtual void stop() = 0;
 
-		virtual ~runtime() {}
+		virtual ~runtime() = default;
+
 	};
 
 	extern "C" runtime* runtime_factory(GLXContext appGLCtx);

--- a/common/stoplight.hpp
+++ b/common/stoplight.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <mutex>
+#include <chrono>
+#include <condition_variable>
+#include "phonebook.hpp"
+
+namespace ILLIXR {
+
+/**
+ * @brief A boolean condition-variable.
+ *
+ * Inspired by https://docs.python.org/3/library/threading.html#event-objects
+ */
+class Event {
+private:
+	mutable std::mutex _m_mutex;
+	mutable std::condition_variable _m_cv;
+	bool _m_value = false;
+
+public:
+
+	/**
+	 * @brief Sets the condition-variable to new_value.
+	 *
+	 * Defaults to true, so that set() sets the bool.
+	 */
+	void set(bool new_value = true) {
+		{
+			std::lock_guard lock {_m_mutex};
+			_m_value = new_value;
+		}
+		if (new_value) {
+			_m_cv.notify_all();
+		}
+	}
+
+	/**
+	 * @brief Clears the condition-variable.
+	 */
+	void clear() { set(false); }
+
+	/**
+	 * @brief Test if is set without blocking.
+	 */
+	bool is_set() const {
+		std::unique_lock<std::mutex> lock {_m_mutex};
+		return _m_value;
+	}
+
+	/**
+	 * @brief Wait indefinitely for the event to be set.
+	 */
+	void wait() const {
+		std::unique_lock<std::mutex> lock {_m_mutex};
+		// Check if we even need to wait
+		if (_m_value) {
+			return;
+		}
+		_m_cv.wait(lock, [this] { return _m_value; });
+	}
+
+	/**
+	 * @brief Wait for the event to be set with a timeout.
+	 *
+	 * Returns whether the event was actually set.
+	 */
+	template <class Clock, class Rep, class Period>
+	bool wait_timeout(const std::chrono::duration<Rep, Period>& duration) const {
+		auto timeout_time = Clock::now() + duration;
+		std::unique_lock<std::mutex> lock {_m_mutex};
+		if (_m_value) {
+			return true;
+		}
+		while (_m_cv.wait_until(lock, timeout_time) != std::cv_status::timeout) {
+			if (_m_value) {
+				return true;
+			}
+		}
+		return false;
+	}
+};
+
+class Stoplight : public phonebook::service {
+public:
+	void wait_for_ready() const {
+		_m_ready.wait();
+	}
+
+	void ready() {
+		_m_ready.set();
+	}
+
+	bool should_stop() const {
+		return _m_stop.load();
+	}
+
+	void stop() {
+		_m_stop.store(true);
+	}
+private:
+	Event _m_ready;
+
+	/*
+	  I use an atomic instead of an event for this one, since it is being "checked" not "waited on."
+
+	  Event uses std::condition_variable, which does not support
+	  std::shared_mutex, so readers would need a std::unique_lock,
+	  which would exclude other readers.
+	*/
+	std::atomic<bool> _m_stop {false};
+};
+
+} // namespace ILLIXR

--- a/common/stoplight.hpp
+++ b/common/stoplight.hpp
@@ -98,8 +98,17 @@ public:
 	void stop() {
 		_m_stop.store(true);
 	}
+
+	void wait_for_shutdown() const {
+		_m_shutdown.wait();
+	}
+
+	void shutdown_done() {
+		_m_shutdown.set();
+	}
 private:
 	Event _m_ready;
+	Event _m_shutdown;
 
 	/*
 	  I use an atomic instead of an event for this one, since it is being "checked" not "waited on."

--- a/common/stoplight.hpp
+++ b/common/stoplight.hpp
@@ -44,7 +44,7 @@ public:
 	 * @brief Test if is set without blocking.
 	 */
 	bool is_set() const {
-		std::unique_lock<std::mutex> lock {_m_mutex};
+		std::lock_guard<std::mutex> lock {_m_mutex};
 		return _m_value;
 	}
 

--- a/common/stoplight.hpp
+++ b/common/stoplight.hpp
@@ -101,14 +101,33 @@ public:
  */
 class Stoplight : public phonebook::service {
 public:
-	const Event& ready() const { return _m_ready; }
-	Event& ready() { return _m_ready; }
+	void wait_for_ready() const {
+		_m_ready.wait();
+	}
 
-	const Event& should_stop() const { return _m_should_stop; }
-	Event& should_stop() { return _m_should_stop; }
+	void signal_ready() {
+		_m_ready.set();
+	}
 
-	const Event& shutdown_complete() const { return _m_shutdown_complete; }
-	Event& shutdown_complete() { return _m_shutdown_complete; }
+	bool check_should_stop() const {
+		return _m_should_stop.is_set();
+	}
+
+	void signal_should_stop() {
+		_m_should_stop.set();
+	}
+
+	void wait_for_shutdown_complete() const {
+		_m_shutdown_complete.wait();
+	}
+
+	bool check_shutdown_complete() const {
+		return _m_shutdown_complete.is_set();
+	}
+
+	void signal_shutdown_complete() {
+		_m_shutdown_complete.set();
+	}
 private:
 	Event _m_ready;
 	Event _m_should_stop;

--- a/common/threadloop.hpp
+++ b/common/threadloop.hpp
@@ -36,6 +36,16 @@ public:
 
 	/**
 	 * @brief Starts the thread.
+	 *
+	 * This cannot go into the constructor because it starts a thread which calls
+	 * `_p_one_iteration()` which is virtual in the child class.
+	 *
+	 * Calling a virtual child method from the parent constructor will not work as expected
+	 * [1]. Instead, the ISO CPP FAQ recommends calling a `start()` method immediately after
+	 * construction [2].
+	 *
+	 * [1]: https://stackoverflow.com/questions/962132/calling-virtual-functions-inside-constructors
+	 * [2]: https://isocpp.org/wiki/faq/strange-inheritance#calling-virtuals-from-ctor-idiom
 	 */
 	virtual void start() override {
 		plugin::start();
@@ -106,6 +116,8 @@ private:
 				break;
 			}
 			case skip_option::stop:
+				// Break out of the switch AND the loop
+				// See https://stackoverflow.com/questions/27788326/breaking-out-of-nested-loop-c
 				goto break_loop;
 			}
 		}

--- a/common/threadloop.hpp
+++ b/common/threadloop.hpp
@@ -50,7 +50,7 @@ public:
 	virtual void start() override {
 		plugin::start();
 		_m_thread = std::thread(std::bind(&threadloop::thread_main, this));
-		assert(!_m_stoplight->should_stop().is_set());
+		assert(!_m_stoplight->check_should_stop());
 		assert(_m_thread.joinable());
 	}
 
@@ -60,13 +60,13 @@ public:
 	 * Must have already stopped the stoplight.
 	 */
 	virtual void stop() override {
-		assert(_m_stoplight->should_stop().is_set());
+		assert(_m_stoplight->check_should_stop());
 		assert(_m_thread.joinable());
 		_m_thread.join();
 	}
 
 	virtual ~threadloop() override {
-		assert(_m_stoplight->should_stop().is_set());
+		assert(_m_stoplight->check_should_stop());
 		assert(!_m_thread.joinable());
 	}
 

--- a/common/threadloop.hpp
+++ b/common/threadloop.hpp
@@ -50,7 +50,7 @@ public:
 	virtual void start() override {
 		plugin::start();
 		_m_thread = std::thread(std::bind(&threadloop::thread_main, this));
-		assert(!_m_stoplight->should_stop());
+		assert(!_m_stoplight->should_stop().is_set());
 		assert(_m_thread.joinable());
 	}
 
@@ -60,13 +60,13 @@ public:
 	 * Must have already stopped the stoplight.
 	 */
 	virtual void stop() override {
-		assert(_m_stoplight->should_stop());
+		assert(_m_stoplight->should_stop().is_set());
 		assert(_m_thread.joinable());
 		_m_thread.join();
 	}
 
 	virtual ~threadloop() override {
-		assert(_m_stoplight->should_stop());
+		assert(_m_stoplight->should_stop().is_set());
 		assert(!_m_thread.joinable());
 	}
 
@@ -82,8 +82,8 @@ private:
 
 		_p_thread_setup();
 
-		while (!_m_stoplight->should_stop()) {
-			_m_stoplight->wait_for_ready();
+		_m_stoplight->ready().wait();
+		while (!_m_stoplight->should_stop().is_set()) {
 			skip_option s = _p_should_skip();
 
 			switch (s) {

--- a/common/threadloop.hpp
+++ b/common/threadloop.hpp
@@ -82,8 +82,8 @@ private:
 
 		_p_thread_setup();
 
-		_m_stoplight->ready().wait();
-		while (!_m_stoplight->should_stop().is_set()) {
+		_m_stoplight->wait_for_ready();
+		while (!_m_stoplight->check_should_stop()) {
 			skip_option s = _p_should_skip();
 
 			switch (s) {

--- a/docs/writing_your_plugin.md
+++ b/docs/writing_your_plugin.md
@@ -65,6 +65,14 @@ You can also replace any existing functionality this way.
     -   If you need custom concurrency (more complicated than a loop),
             triggered concurrency (by events fired in other plugins),
             or no concurrency then your plugin class should extend [`plugin`][13].
+			
+        - If you spin your own threads, they **must** wait for
+          `pb->lookup_impl<Stoplight>()->wait_for_ready()` the first time they
+          run. This allows the start of all threads in ILLIXR to be
+          synchronized.
+
+        - They **must** be joined-or-disowned at-or-before
+          `plugin::stop()`. This allows ILLIXR to shutdown cleanly.
 
 1.  Write a file called `plugin.cpp` with this body, replacing every instance of `plugin_name`:
 

--- a/runtime/runtime_impl.hpp
+++ b/runtime/runtime_impl.hpp
@@ -49,8 +49,11 @@ public:
 		});
 
 		std::for_each(plugins.cbegin(), plugins.cend(), [](const auto& plugin) {
+			// Well-behaved plugins (any derived from threadloop) start there threads here, and then wait on the Stoplight.
 			plugin->start();
 		});
+
+		// This actually kicks off the plugins
 		pb.lookup_impl<Stoplight>()->ready();
 	}
 
@@ -82,7 +85,7 @@ public:
 
 	virtual ~runtime_impl() override {
 		if (!pb.lookup_impl<Stoplight>()->should_stop()) {
-            ILLIXR::abort("You didn't call stop() before destructing this plugin.");
+            ILLIXR::abort("You didn't call stop() before destructing the runtime.");
 		}
 		// This will be re-enabled in #225
 		// assert(errno == 0 && "errno was set during run. Maybe spurious?");

--- a/runtime/runtime_impl.hpp
+++ b/runtime/runtime_impl.hpp
@@ -54,7 +54,7 @@ public:
 		});
 
 		// This actually kicks off the plugins
-		pb.lookup_impl<Stoplight>()->ready().set();
+		pb.lookup_impl<Stoplight>()->signal_ready();
 	}
 
 	virtual void load_so(const std::string_view so) override {
@@ -72,11 +72,11 @@ public:
 	virtual void wait() override {
 		// We don't want wait() returning before all the plugin threads have been joined.
 		// That would cause a nasty race-condition if the client tried to delete the runtime right after wait() returned.
-		pb.lookup_impl<Stoplight>()->shutdown_complete().wait();
+		pb.lookup_impl<Stoplight>()->wait_for_shutdown_complete();
 	}
 
 	virtual void stop() override {
-		pb.lookup_impl<Stoplight>()->should_stop().set();
+		pb.lookup_impl<Stoplight>()->signal_should_stop();
 		// After this point, threads may exit their main loops
 		// They still have destructors and still have to be joined.
 
@@ -89,11 +89,11 @@ public:
 		}
 
 		// Tell runtime::wait() that it can return
-		pb.lookup_impl<Stoplight>()->shutdown_complete().set();
+		pb.lookup_impl<Stoplight>()->signal_shutdown_complete();
 	}
 
 	virtual ~runtime_impl() override {
-		if (!pb.lookup_impl<Stoplight>()->should_stop().is_set()) {
+		if (!pb.lookup_impl<Stoplight>()->check_shutdown_complete()) {
 			stop();
 		}
 		// This will be re-enabled in #225

--- a/runtime/runtime_impl.hpp
+++ b/runtime/runtime_impl.hpp
@@ -54,7 +54,7 @@ public:
 		});
 
 		// This actually kicks off the plugins
-		pb.lookup_impl<Stoplight>()->ready();
+		pb.lookup_impl<Stoplight>()->ready().set();
 	}
 
 	virtual void load_so(const std::string_view so) override {
@@ -70,17 +70,13 @@ public:
 	}
 
 	virtual void wait() override {
-		while (!pb.lookup_impl<Stoplight>()->should_stop()) {
-			std::this_thread::sleep_for(std::chrono::milliseconds{10});
-		}
-
 		// We don't want wait() returning before all the plugin threads have been joined.
 		// That would cause a nasty race-condition if the client tried to delete the runtime right after wait() returned.
-		pb.lookup_impl<Stoplight>()->wait_for_shutdown();
+		pb.lookup_impl<Stoplight>()->shutdown_complete().wait();
 	}
 
 	virtual void stop() override {
-		pb.lookup_impl<Stoplight>()->stop();
+		pb.lookup_impl<Stoplight>()->should_stop().set();
 		// After this point, threads may exit their main loops
 		// They still have destructors and still have to be joined.
 
@@ -93,11 +89,11 @@ public:
 		}
 
 		// Tell runtime::wait() that it can return
-		pb.lookup_impl<Stoplight>()->shutdown_done();
+		pb.lookup_impl<Stoplight>()->shutdown_complete().set();
 	}
 
 	virtual ~runtime_impl() override {
-		if (!pb.lookup_impl<Stoplight>()->should_stop()) {
+		if (!pb.lookup_impl<Stoplight>()->should_stop().is_set()) {
 			stop();
 		}
 		// This will be re-enabled in #225


### PR DESCRIPTION
This is less critical than #32. Only review if the path to #32 is blocked up.

Closes #217.

Reviewer should
- See how it works (note the `std::condition_variable` code is lifted from [C++ docs](https://en.cppreference.com/w/cpp/thread/condition_variable)).
- Verify that API of `Stoplight` is sane.
- Ensure it works on your machine.