### PR TITLE
Fixed multiple definitions in global helper functions

### DIFF
--- a/common/global_module_defs.hpp
+++ b/common/global_module_defs.hpp
@@ -26,14 +26,14 @@ static constexpr int FB_HEIGHT = 1440; //Pixels
 /**
  * @brief Convert a string containing a (python) boolean to the bool type
  */
-bool str_to_bool(std::string var) {
+inline bool str_to_bool(std::string var) {
     return (var == "True")  ? true  :
            (var == "False") ? false :
            throw std::runtime_error("Invalid conversion from std::string to bool");
 }
 
 /// Temporary environment variable getter. Not needed once #198 is merged.
-std::string getenv_or(std::string var, std::string default_) {
+inline std::string getenv_or(std::string var, std::string default_) {
     if (std::getenv(var.c_str())) {
         return {std::getenv(var.c_str())};
     } else {


### PR DESCRIPTION
Closes #253.

Inlines globally included functions from `ILLIXR/common/global_module_defs.hpp`.