### PR TITLE
Hotfix: Added Git tags for `monado_integration` and fixed `clean` for `configs/clean.yaml`

### DIFF
--- a/common/common.mk
+++ b/common/common.mk
@@ -3,6 +3,7 @@
 CXX := clang++-10
 STDCXX ?= c++17
 CFLAGS := $(CFLAGS) -DGLSL_VERSION='"330 core"'
+RM := rm -f
 
 ## DBG Notes:
 #> -Og and -g provide additional debugging symbols

--- a/configs/clean.yaml
+++ b/configs/clean.yaml
@@ -5,6 +5,7 @@ plugin_groups:
   - plugin_group:
     ## Runtime
     - path: runtime
+    - path: common
     ## Core Plugins
     - path: timewarp_gl
     - name: audio

--- a/configs/monado.yaml
+++ b/configs/monado.yaml
@@ -18,11 +18,11 @@ action:
   monado:
     path:
       git_repo: https://github.com/ILLIXR/monado_integration.git
-      version: master
+      version: "2.0"
   openxr_app:
     path:
       git_repo: https://github.com/ILLIXR/Monado_OpenXR_Simple_Example.git
-      version: master
+      version: "2.0"
     config: {}
   kimera_path: .cache/paths/https%c%s%sgithub.com%sILLIXR%sKimera-VIO/
   


### PR DESCRIPTION
Closes #260.
- Git tags are now used in `ILLIXR/configs/monado.yaml'.