### PR TITLE
Fixed `pose_lookup` and `dynamic_lib`

### DIFF
--- a/common/dynamic_lib.hpp
+++ b/common/dynamic_lib.hpp
@@ -25,28 +25,28 @@ Usage:
 
 class dynamic_lib {
 private:
-	dynamic_lib(
-	    void_ptr&& handle
+    dynamic_lib(
+        void_ptr&& handle
         , const std::string& lib_name = ""
-	) : _m_handle{std::move(handle)}
+    ) : _m_handle{std::move(handle)}
       , _m_lib_name{std::move(lib_name)}
-	{ }
+    { }
 
 public:
-	dynamic_lib(dynamic_lib&& other)
-		: _m_handle{std::move(other._m_handle)}
+    dynamic_lib(dynamic_lib&& other)
+        : _m_handle{std::move(other._m_handle)}
         , _m_lib_name{std::move(other._m_lib_name)}
-	{ }
+    { }
 
-	dynamic_lib& operator=(dynamic_lib&& other) {
-		if (this != &other) {
-			_m_handle   = std::move(other._m_handle);
-			_m_lib_name = std::move(other._m_lib_name);
-		}
-		return *this;
-	}
+    dynamic_lib& operator=(dynamic_lib&& other) {
+        if (this != &other) {
+            _m_handle   = std::move(other._m_handle);
+            _m_lib_name = std::move(other._m_lib_name);
+        }
+        return *this;
+    }
 
-	~dynamic_lib() {
+    ~dynamic_lib() {
 #ifndef NDEBUG
         if (_m_lib_name.size() > 0U) {
             std::cout << "[dynamic_lib] Destructing library : " << _m_lib_name << std::endl;
@@ -54,12 +54,12 @@ public:
 #endif /// NDEBUG
     }
 
-	static dynamic_lib create(const std::string& path) {
-		return dynamic_lib::create(std::string_view{path.c_str()});
-	}
+    static dynamic_lib create(const std::string& path) {
+        return dynamic_lib::create(std::string_view{path.c_str()});
+    }
 
-	static dynamic_lib create(const std::string_view& path) {
-		char* error;
+    static dynamic_lib create(const std::string_view& path) {
+        char* error;
 
         const std::size_t path_basename_end        {path.find_last_of("/")};
         const std::size_t path_basename_begin_tmp  {path.rfind("/", path_basename_end - 1U)};
@@ -80,19 +80,19 @@ public:
         std::cout << "[dynamic_lib] Opening library : " << path_basename << std::endl;
 #endif /// NDEBUG
 
-		// dlopen man page says that it can set errno sp
-		RAC_ERRNO_MSG("dynamic_lib before dlopen");
-		void* handle = dlopen(path.data(), RTLD_LAZY | RTLD_LOCAL);
-		RAC_ERRNO_MSG("dynamic_lib after dlopen");
+        // dlopen man page says that it can set errno sp
+        RAC_ERRNO_MSG("dynamic_lib before dlopen");
+        void* handle = dlopen(path.data(), RTLD_LAZY | RTLD_LOCAL);
+        RAC_ERRNO_MSG("dynamic_lib after dlopen");
 
-		if ((error = dlerror()) || !handle) {
-			throw std::runtime_error{
-				"dlopen(\"" + std::string{path} + "\"): " + (error == nullptr ? "NULL" : std::string{error})
-			};
+        if ((error = dlerror()) || !handle) {
+            throw std::runtime_error{
+                "dlopen(\"" + std::string{path} + "\"): " + (error == nullptr ? "NULL" : std::string{error})
+            };
         }
 
-		return dynamic_lib{
-		    void_ptr{handle, [](void* handle) {
+        return dynamic_lib{
+            void_ptr{handle, [](void* handle) {
                 RAC_ERRNO();
 
                 char* error;
@@ -107,33 +107,33 @@ public:
                     throw std::runtime_error{msg_error};
 #endif /// NDEBUG
                 }
-		    }}
-		    , path_basename /// Keep the dynamic lib name for debugging
-		};
-	}
+            }}
+            , path_basename /// Keep the dynamic lib name for debugging
+        };
+    }
 
-	const void* operator[](const std::string& symbol_name) const {
-		RAC_ERRNO_MSG("dynamic_lib at start of operator[]");
+    const void* operator[](const std::string& symbol_name) const {
+        RAC_ERRNO_MSG("dynamic_lib at start of operator[]");
 
-		char* error;		
-		void* symbol = dlsym(_m_handle.get(), symbol_name.c_str());
-		if ((error = dlerror())) {
-			throw std::runtime_error{
-				"dlsym(\"" + symbol_name + "\"): " + (error == nullptr ? "NULL" : std::string{error})
-			};
+        char* error;
+        void* symbol = dlsym(_m_handle.get(), symbol_name.c_str());
+        if ((error = dlerror())) {
+            throw std::runtime_error{
+                "dlsym(\"" + symbol_name + "\"): " + (error == nullptr ? "NULL" : std::string{error})
+            };
         }
-		return symbol;
-	}
+        return symbol;
+    }
 
-	template <typename T>
-	const T get(const std::string& symbol_name) const {
-		const void* obj = (*this)[symbol_name];
-		// return reinterpret_cast<const T>((*this)[symbol_name]);
-		return (const T) obj;
-	}
+    template <typename T>
+    const T get(const std::string& symbol_name) const {
+        const void* obj = (*this)[symbol_name];
+        // return reinterpret_cast<const T>((*this)[symbol_name]);
+        return (const T) obj;
+    }
 
 private:
-	void_ptr _m_handle;
+    void_ptr _m_handle;
     std::string _m_lib_name;
 };
 

--- a/common/dynamic_lib.hpp
+++ b/common/dynamic_lib.hpp
@@ -71,9 +71,9 @@ public:
 
 #ifndef NDEBUG
         const std::size_t path_basename_end        {path.find_last_of("/")};
-        const std::size_t path_basename_begin_tmp  {path.rfind("/", path_basename_end - 1)};
-        const std::size_t path_basename_begin      {(path_basename_begin_tmp == std::string::npos) ? 0U : path_basename_begin_tmp + 1};
-        const std::size_t path_basename_size       {path_basename_end - path_basename_begin + 1};
+        const std::size_t path_basename_begin_tmp  {path.rfind("/", path_basename_end - 1U)};
+        const std::size_t path_basename_begin      {(path_basename_begin_tmp == std::string::npos) ? 0U : path_basename_begin_tmp + 1U};
+        const std::size_t path_basename_size       {path_basename_end - path_basename_begin + 1U};
 
         std::vector<char> path_basename_buf;
         path_basename_buf.resize(path_basename_size);

--- a/common/dynamic_lib.hpp
+++ b/common/dynamic_lib.hpp
@@ -61,18 +61,6 @@ public:
     static dynamic_lib create(const std::string_view& path) {
         char* error;
 
-        /// The contents of a string_view must not outlive the parent string
-        /// Copy the contents passed to create into a new string
-        std::vector<char> path_buf;
-        path_buf.resize(path.size() + 1U);
-        std::copy(path.cbegin(), path.cend(), path_buf.begin());
-        path_buf.back() = '\0';
-
-        std::string path_copy {path_buf.cbegin(), path_buf.cend()};
-#ifndef NDEBUG
-        std::cout << "[dynamic_lib] Opening library : " << path_copy << std::endl;
-#endif /// NDEBUG
-
         // dlopen man page says that it can set errno sp
         RAC_ERRNO_MSG("dynamic_lib before dlopen");
         void* handle = dlopen(path.data(), RTLD_LAZY | RTLD_LOCAL);
@@ -101,7 +89,7 @@ public:
 #endif /// NDEBUG
                 }
             }},
-            path_copy /// Keep the dynamic lib name for debugging
+            std::string{path} /// Keep the dynamic lib name for debugging
         };
     }
 

--- a/common/dynamic_lib.hpp
+++ b/common/dynamic_lib.hpp
@@ -27,40 +27,32 @@ class dynamic_lib {
 private:
 	dynamic_lib(
 	    void_ptr&& handle
-#ifndef NDEBUG
         , const std::string& lib_name = ""
-#endif /// NDEBUG
 	) : _m_handle{std::move(handle)}
-#ifndef NDEBUG
       , _m_lib_name{std::move(lib_name)}
-#endif /// NDEBUG
 	{ }
 
 public:
 	dynamic_lib(dynamic_lib&& other)
 		: _m_handle{std::move(other._m_handle)}
-#ifndef NDEBUG
         , _m_lib_name{std::move(other._m_lib_name)}
-#endif /// NDEBUG
 	{ }
 
 	dynamic_lib& operator=(dynamic_lib&& other) {
 		if (this != &other) {
 			_m_handle   = std::move(other._m_handle);
-#ifndef NDEBUG
 			_m_lib_name = std::move(other._m_lib_name);
-#endif /// NDEBUG
 		}
 		return *this;
 	}
 
-#ifndef NDEBUG
 	~dynamic_lib() {
+#ifndef NDEBUG
         if (_m_lib_name.size() > 0U) {
             std::cout << "[dynamic_lib] Destructing library : " << _m_lib_name << std::endl;
         }
-    }
 #endif /// NDEBUG
+    }
 
 	static dynamic_lib create(const std::string& path) {
 		return dynamic_lib::create(std::string_view{path.c_str()});
@@ -69,7 +61,6 @@ public:
 	static dynamic_lib create(const std::string_view& path) {
 		char* error;
 
-#ifndef NDEBUG
         const std::size_t path_basename_end        {path.find_last_of("/")};
         const std::size_t path_basename_begin_tmp  {path.rfind("/", path_basename_end - 1U)};
         const std::size_t path_basename_begin      {(path_basename_begin_tmp == std::string::npos) ? 0U : path_basename_begin_tmp + 1U};
@@ -85,6 +76,7 @@ public:
         path_basename_buf.back() = '\0';
 
         std::string path_basename {path_basename_buf.cbegin(), path_basename_buf.cend()};
+#ifndef NDEBUG
         std::cout << "[dynamic_lib] Opening library : " << path_basename << std::endl;
 #endif /// NDEBUG
 
@@ -116,9 +108,7 @@ public:
 #endif /// NDEBUG
                 }
 		    }}
-#ifndef NDEBUG
 		    , path_basename /// Keep the dynamic lib name for debugging
-#endif /// NDEBUG
 		};
 	}
 
@@ -144,9 +134,7 @@ public:
 
 private:
 	void_ptr _m_handle;
-#ifndef NDEBUG
     std::string _m_lib_name;
-#endif /// NDEBUG
 };
 
 }

--- a/common/dynamic_lib.hpp
+++ b/common/dynamic_lib.hpp
@@ -80,13 +80,8 @@ public:
                 int ret = dlclose(handle);
                 if ((error = dlerror()) || ret) {
                     const std::string msg_error {"dlclose(): " + (error == nullptr ? "NULL" : std::string{error})};
-#ifndef NDEBUG
-                    /// If debugging, only report the dlclose error (non-fatal, can leak memory)
                     std::cerr << "[dynamic_lib] " << msg_error << std::endl;
-#else
-                    /// If not debugging, raise the dlclose error (fatal)
                     throw std::runtime_error{msg_error};
-#endif /// NDEBUG
                 }
             }},
             std::string{path} /// Keep the dynamic lib name for debugging

--- a/pose_lookup/plugin.cpp
+++ b/pose_lookup/plugin.cpp
@@ -24,10 +24,10 @@ public:
         , _m_vsync_estimate{sb->get_reader<switchboard::event_wrapper<time_type>>("vsync_estimate")}
         /// TODO: Set with #198
         , enable_alignment{ILLIXR::str_to_bool(getenv_or("ILLIXR_ALIGNMENT_ENABLE", "False"))}
-        , init_pos_offset{0}
+        , init_pos_offset{Eigen::Vector3f::Zero()}
         , align_rot{Eigen::Matrix3f::Zero()}
-        , align_trans{0}
-        , align_quat{0}
+        , align_trans{Eigen::Vector3f::Zero()}
+        , align_quat{Eigen::Vector4f::Zero()}
         , align_scale{0.0}
         , path_to_alignment{ILLIXR::getenv_or("ILLIXR_ALIGNMENT_FILE", "./metrics/alignMatrix.txt")}
     {


### PR DESCRIPTION
Closes #303 .
- Fixed `pose_lookup` initialization in `pose_lookup/plugin.cpp`
- Added debugging prints to `common/dynamic_lib.hpp`
- New `path_basename` for debugging in `common/dynamic_lib.hpp`
- Failed calls to `dlclose` non-fatal with `dbg` in `common/dynamic_lib.hpp`