### PR TITLE
Realsense moved

### DIFF
--- a/scripts/install_apt_deps.sh
+++ b/scripts/install_apt_deps.sh
@@ -351,7 +351,7 @@ fi
 # If supported, add the gpg keys and repository for Intel RealSense
 if [ "${use_realsense}" = "yes" ]; then
     key_srv_url_list_realsense="keys.gnupg.net hkp://keyserver.ubuntu.com:80"
-    repo_url_realsense="http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo"
+    repo_url_realsense="http://librealsense.intel.com/Debian/apt-repo"
     key_id_realsense="F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE"
     add_repo "${key_srv_url_list_realsense}" "${repo_url_realsense}" "${distro_codename} main" "${key_id_realsense}"
 fi


### PR DESCRIPTION
Realsense moved their APT repo to a [new location](https://github.com/IntelRealSense/librealsense/commit/9ec146bf5a120fd8a0988296fe3e0daad2da73ff#diff-c89e6403d9d8d64c6a094e39b24f5a368d8a8c40ec7fc02a0e4d6086b1257162).

This was discussed on our Discord [here](https://discord.com/channels/830812443189444698/830835038928371772/868225230701740132).