### PR TITLE
Revert boost install script

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -25,11 +25,12 @@ export script_path_apt="scripts/install_apt_deps.sh"
 #export dep_ver_clang="llvmorg-10.0.1"
 
 ## Boost
-export dep_name_boost="boost"
-export script_path_boost="scripts/install_boost.sh"
-export parent_dir_boost="${opt_dir}"
-export dep_prompt_boost="Install Boost from source"
-export dep_ver_boost="boost-1.65.1"
+## Locally built boost not in use yet
+#export dep_name_boost="boost"
+#export script_path_boost="scripts/install_boost.sh"
+#export parent_dir_boost="${opt_dir}"
+#export dep_prompt_boost="Install Boost from source"
+#export dep_ver_boost="boost-1.65.1"
 
 ## OpenCV
 export dep_name_opencv="opencv"

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -269,13 +269,14 @@ fi
 #    "${dep_prompt_clang}" \
 #    "${dep_ver_clang}"
 
-prompt_install \
-    "${dep_name_boost}" \
-    "${deps_log_dir}" \
-    "${script_path_boost}" \
-    "${parent_dir_boost}" \
-    "${dep_prompt_boost}" \
-    "${dep_ver_boost}"
+## Locally built boost not in use yet
+#prompt_install \
+#    "${dep_name_boost}" \
+#    "${deps_log_dir}" \
+#    "${script_path_boost}" \
+#    "${parent_dir_boost}" \
+#    "${dep_prompt_boost}" \
+#    "${dep_ver_boost}"
 
 prompt_install \
     "${dep_name_opencv}" \


### PR DESCRIPTION
This reverts commit 8590c7422c9e0e72d11df0717cee201a12cb00d0.
We do not need to build boost ourselves, the one from apt works just fine.