### PR TITLE
Adding rk4_integrator to monado-mainline.yaml

### DIFF
--- a/configs/monado-mainline.yaml
+++ b/configs/monado-mainline.yaml
@@ -3,6 +3,7 @@ plugin_groups:
     - path: offline_imu_cam
     - path: gtsam_integrator
     - path: pose_prediction
+    - path: rk4_integrator
     - name: OpenVINS
       path:
         git_repo : https://github.com/ILLIXR/open_vins.git

--- a/configs/monado-mainline.yaml
+++ b/configs/monado-mainline.yaml
@@ -1,7 +1,7 @@
 plugin_groups:
   - plugin_group:
     - path: offline_imu_cam
-    - path: gtsam_integrator
+    #- path: gtsam_integrator
     - path: pose_prediction
     - path: rk4_integrator
     - name: OpenVINS


### PR DESCRIPTION
Closes #325 

Head poses are incorrect when running Unreal application with ILLIXR because IMU integrator is not listed as a plugin in `monado-mainline.yaml`. Adding `rk4_integrator` helps resolve the issue.