### PR TITLE
Update CUDA key in install_deps, plus minor documentation fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@
 
 Sarita V. Adve <sadve@illinois.edu>
 Dhairya Bahl <dhairyabahl5@gmail.com>
+Charles Block <coblock2@illinois.edu>
 Henry Che <hungdc2@illinois.edu>
 Rishi Desai <rishipd2@illinois.edu>
 Sam Grayson <grayson5@illinois.edu>

--- a/docs/illixr_plugins.md
+++ b/docs/illixr_plugins.md
@@ -109,7 +109,7 @@ Read the [API documentation on _Switchboard_][32] for more information.
     style="width: 400px;"
 />
 
--   In the above figure, rectangles are plugins.
+-   In the above figure, ovals are plugins.
 
 -   Solid arrows from plugins to topics represent publishing.
 

--- a/runner/runner/main.py
+++ b/runner/runner/main.py
@@ -268,7 +268,7 @@ def load_monado(config: Mapping[str, Any]) -> None:
     else:
         ## Get the full path to the 'app' binary
         openxr_app_path     = None
-        openxr_app_bin_path = pathify(openxr_app_obj["app"], root_dir, cache_path, True, True)
+        openxr_app_bin_path = pathify(openxr_app_obj["app"], root_dir, cache_path, True, False)
 
     ## Compile the OpenXR app if we received an 'app' with 'src_path'
     if openxr_app_path:

--- a/scripts/install_apt_deps.sh
+++ b/scripts/install_apt_deps.sh
@@ -359,8 +359,15 @@ fi
 # If supported, add the keys and repository for CUDA (for GPU plugin support)
 if [ "${use_cuda}" = "yes" ]; then
     repo_url_cuda="https://developer.download.nvidia.com/compute/cuda/repos/${distro_name_cuda}/${arch_name_cuda}"
-    key_srv_url_cuda="${repo_url_cuda}/7fa2af80.pub"
-    add_repo "${key_srv_url_cuda}" "${repo_url_cuda}" "/"
+    
+    # Install the keys from the repo using nvidia's key package
+    key_pkg_name_cuda="cuda-keyring_1.0-1_all.deb"
+    key_pkg_url_cuda="${repo_url_cuda}/${key_pkg_name_cuda}"
+    wget ${key_pkg_url_cuda}
+    sudo apt-get install -y -q "./${key_pkg_name_cuda}"
+    rm "./${key_pkg_name_cuda}"
+
+    add_repo "" "${repo_url_cuda}" "/"
 
     path_cmd_cuda='export PATH=/usr/local/cuda-11.1/bin${PATH:+:${PATH}}'
     lib64_cmd_cuda='export LD_LIBRARY_PATH=/usr/local/cuda-11.1/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}'


### PR DESCRIPTION
Nvidia changed their keys for cuda earlier this year, and I think this update should fix that for our dependency installation script.

Also, a minor typo in the documentation.

Closes #349 