### PR TITLE
Fix order of matrix multiplication

### DIFF
--- a/gldemo/plugin.cpp
+++ b/gldemo/plugin.cpp
@@ -152,7 +152,7 @@ public:
             // Objects' "view matrix" is inverse of eye matrix.
             auto view_matrix = eye_matrix.inverse();
 
-            Eigen::Matrix4f modelViewMatrix = modelMatrix * view_matrix;
+            Eigen::Matrix4f modelViewMatrix = view_matrix * modelMatrix;
             glUniformMatrix4fv(modelViewAttr, 1, GL_FALSE, (GLfloat*) (modelViewMatrix.data()));
             glUniformMatrix4fv(projectionAttr, 1, GL_FALSE, (GLfloat*) (basicProjection.data()));
 


### PR DESCRIPTION
Fixes #362, the model matrix should be multiplied before the view matrix (order of operations is projection * view * model).