### PR TITLE
Add support for aarch64 in installation scripts

### DIFF
--- a/runner/environment-aarch64.yml
+++ b/runner/environment-aarch64.yml
@@ -1,0 +1,22 @@
+########
+# To add packages to this file:
+#
+#     . $HOME/miniconda3/etc/profile.d/conda.sh
+#     conda deactivate
+#     conda activate illixr-runner
+#     conda install $package # where $packages is the name of a package in Conda Forge
+#     conda env export > runner/environment.yml
+#
+# Please be a good citizen and also copy/resotre this block comment!!
+########
+name: illixr-runner
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - click=8.0.4
+  - jsonschema=4.17.3
+  - pyyaml=6.0
+  - pip:
+    - pyyaml-include==1.3
+prefix: /opt/ILLIXR/miniconda3/envs/illixr-runner

--- a/scripts/install_apt_deps.sh
+++ b/scripts/install_apt_deps.sh
@@ -234,8 +234,8 @@ if [ "${distro_name}" = "ubuntu" ] && ([ "${distro_version}" = "18.04" ] || [ "$
                     pkg_dep_groups+=" realsense_anyarch"
                     pkg_dep_groups+=" realsense_x86_64"
                     ;;
-        aarch64)    use_realsense="yes"
-                    pkg_dep_groups+=" realsense_anyarch"
+        aarch64)    use_realsense="no"
+                    # pkg_dep_groups+=" realsense_anyarch"
                     ;;
         *)          print_warning "Unsupported arch '${arch_name}' for Intel RealSense."
                     exit 1

--- a/scripts/install_conda.sh
+++ b/scripts/install_conda.sh
@@ -37,7 +37,7 @@ script_path="${src_dir}/miniconda.sh"
 ### Checks ###
 
 case "${arch_name}" in
-    x86_64)
+    x86_64|aarch64)
         check_cmd_conda=$(conda --version 2>/dev/null)
         if [ "$?" -eq 0 ]; then
             ## Conda found

--- a/scripts/install_gtsam.sh
+++ b/scripts/install_gtsam.sh
@@ -65,7 +65,8 @@ cmake \
     -D GTSAM_USE_SYSTEM_EIGEN=ON \
     -D GTSAM_POSE3_EXPMAP=ON \
     -D GTSAM_ROT3_EXPMAP=ON \
-    -D GTSAM_WITH_EIGEN_UNSUPPORTED=ON
+    -D GTSAM_WITH_EIGEN_UNSUPPORTED=ON \
+    -D GTSAM_BUILD_WITH_MARCH_NATIVE=OFF
 make -C "${build_dir}" -j "${illixr_nproc}"
 
 ## Install


### PR DESCRIPTION
Adds support in the installation scripts for aarch64. Tested on Ubuntu 20.04 aarch64.