### PR TITLE
Make Phonebook and Switchboard compatible with Android Studio Compiler

### DIFF
--- a/common/phonebook.hpp
+++ b/common/phonebook.hpp
@@ -128,8 +128,10 @@ public:
 
         std::shared_ptr<service> this_service = _m_registry.at(type_index.name());
         assert(this_service);
-        auto this_specific_service_auto = (reinterpret_cast<typename std::shared_ptr<specific_service>::element_type*>(this_service.get()));
-        std::shared_ptr<specific_service> this_specific_service = std::shared_ptr<specific_service>{this_service, this_specific_service_auto};
+        auto this_specific_service_auto =
+            (reinterpret_cast<typename std::shared_ptr<specific_service>::element_type*>(this_service.get()));
+        std::shared_ptr<specific_service> this_specific_service =
+            std::shared_ptr<specific_service>{this_service, this_specific_service_auto};
 
         assert(this_specific_service);
 
@@ -138,6 +140,6 @@ public:
 
 private:
     std::unordered_map<std::string, const std::shared_ptr<service>> _m_registry;
-    mutable std::shared_mutex                                           _m_mutex;
+    mutable std::shared_mutex                                       _m_mutex;
 };
 } // namespace ILLIXR

--- a/common/switchboard.hpp
+++ b/common/switchboard.hpp
@@ -473,9 +473,11 @@ public:
          * This will return null if no event is on the topic yet.
          */
         ptr<const specific_event> get_ro_nullable() const noexcept {
-            ptr<const event>          this_event          = _m_topic.get();
-            auto this_specific_event_auto = (reinterpret_cast<typename std::shared_ptr<const specific_event>::element_type*>(this_event.get()));
-            ptr<const specific_event> this_specific_event = std::shared_ptr<const specific_event>{this_event, this_specific_event_auto};
+            ptr<const event> this_event = _m_topic.get();
+            auto             this_specific_event_auto =
+                (reinterpret_cast<typename std::shared_ptr<const specific_event>::element_type*>(this_event.get()));
+            ptr<const specific_event> this_specific_event =
+                std::shared_ptr<const specific_event>{this_event, this_specific_event_auto};
 
             if (this_event != nullptr) {
                 assert(this_specific_event /* Otherwise, dynamic cast failed; dynamic type information could be wrong*/);
@@ -535,9 +537,11 @@ public:
             // CPU_TIMER_TIME_EVENT_INFO(true, false, "callback", cpu_timer::make_type_eraser<FrameInfo>("", _m_topic.name(),
             // serial_no));
             serial_no++;
-            ptr<const event>          this_event          = _m_tb.dequeue();
-            auto this_specific_event_auto = (reinterpret_cast<typename std::shared_ptr<const specific_event>::element_type*>(this_event.get()));
-            ptr<const specific_event> this_specific_event = std::shared_ptr<const specific_event>{this_event, this_specific_event_auto};
+            ptr<const event> this_event = _m_tb.dequeue();
+            auto             this_specific_event_auto =
+                (reinterpret_cast<typename std::shared_ptr<const specific_event>::element_type*>(this_event.get()));
+            ptr<const specific_event> this_specific_event =
+                std::shared_ptr<const specific_event>{this_event, this_specific_event_auto};
             return this_specific_event;
         }
     };
@@ -639,8 +643,10 @@ public:
         try_register_topic<specific_event>(topic_name)
             .schedule(plugin_id, [=](ptr<const event>&& this_event, std::size_t it_no) {
                 assert(this_event);
-                auto this_specific_event_auto = (reinterpret_cast<typename std::shared_ptr<const specific_event>::element_type*>(this_event.get()));
-                ptr<const specific_event> this_specific_event = std::shared_ptr<const specific_event>{this_event, this_specific_event_auto};
+                auto this_specific_event_auto =
+                    (reinterpret_cast<typename std::shared_ptr<const specific_event>::element_type*>(this_event.get()));
+                ptr<const specific_event> this_specific_event =
+                    std::shared_ptr<const specific_event>{this_event, this_specific_event_auto};
                 assert(this_specific_event);
                 fn(std::move(this_specific_event), it_no);
             });


### PR DESCRIPTION
There are two main changes in this commit:

1. Switchboard: Change all dynamic_pointer_cast to reinterpret_pointer_cast so that switchboard works with Android Studio Compiler. 
2. Phonebook: A struct compiled in different compilation units (plugins) may not have the same type index assigned by the Android compiler (or other compilers) thus use type_index.name as the key to the hashmap _m_registry. 
type_index.name seems to be working in both Desktop and Android Studio.