### PR TITLE
Minor fixes

### DIFF
--- a/common/data_format.hpp
+++ b/common/data_format.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <boost/optional.hpp>
-#include <chrono>
-#include <iostream>
 #include <memory>
 #include <opencv2/core/mat.hpp>
 #undef Success // For 'Success' conflict

--- a/common/relative_clock.hpp
+++ b/common/relative_clock.hpp
@@ -120,8 +120,8 @@ public:
      * @brief Starts the clock. All times are relative to this point.
      */
     void start() {
-        _m_start = std::chrono::steady_clock::now();
-	_m_started = true;
+        _m_start   = std::chrono::steady_clock::now();
+        _m_started = true;
     }
 
     /**

--- a/common/relative_clock.hpp
+++ b/common/relative_clock.hpp
@@ -102,7 +102,7 @@ public:
     using rep                       = _clock_rep;
     using period                    = _clock_period;
     using duration                  = _clock_duration;
-    using time_point                = time_point;
+    using time_point                = ILLIXR::time_point;
     static constexpr bool is_steady = true;
     static_assert(std::chrono::steady_clock::is_steady);
 
@@ -121,17 +121,19 @@ public:
      */
     void start() {
         _m_start = std::chrono::steady_clock::now();
+	_m_started = true;
     }
 
     /**
      * @brief Check if the clock is started.
      */
     bool is_started() const {
-        return _m_start > std::chrono::steady_clock::time_point{};
+        return _m_started;
     }
 
 private:
     std::chrono::steady_clock::time_point _m_start;
+    bool                                  _m_started;
 };
 
 using duration = RelativeClock::duration;


### PR DESCRIPTION
While working on my XROS project, I found a couple of things that I felt could be improved upon, and Yihan suggested turning these suggestions into a PR, so I did.

The main things I changed were:
1. The `RelativeClock` implementation was a bit hard to follow, so I modified the implementation a little bit.
2. I removed some unused headers in `common/data_format.hpp`.
3. When I was trying to compile a simple `main.cpp` which included `common/data_format.hpp` with GCC 9.4.0, I got a "Declaration of `time_point` changes meaning of `time_point`" error on [this line](https://github.com/ILLIXR/ILLIXR/blob/e17e6c5679822a4f021d0a6f85628b5ab698b384/common/relative_clock.hpp#L105). After some research, it turns out that [GCC emits a warning when this happens whereas Clang doesn't](https://stackoverflow.com/a/15538759), so I fixed it.