### PR TITLE
Fix zed

### DIFF
--- a/gtsam_integrator/plugin.cpp
+++ b/gtsam_integrator/plugin.cpp
@@ -17,9 +17,6 @@
 #include <iomanip>
 #include <thread>
 
-#include <filesystem>
-#include <fstream>
-
 using namespace ILLIXR;
 // IMU sample time to live in seconds
 constexpr duration IMU_TTL{std::chrono::seconds{5}};
@@ -34,13 +31,6 @@ public:
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , _m_imu_integrator_input{sb->get_reader<imu_integrator_input>("imu_integrator_input")}
         , _m_imu_raw{sb->get_writer<imu_raw_type>("imu_raw")} {
-
-        if (!std::filesystem::exists(data_path)) {
-            if (!std::filesystem::create_directory(data_path)) {
-                std::cerr << "Failed to create data directory.";
-            }
-        }
-        raw_csv.open(data_path + "/imu_raw.csv");
 
         sb->schedule<imu_type>(id, "imu", [&](switchboard::ptr<const imu_type> datum, size_t) {
             callback(datum);
@@ -71,8 +61,6 @@ private:
     [[maybe_unused]] time_point last_cam_time;
     duration                    last_imu_offset;
 
-    const std::string data_path = std::filesystem::current_path().string() + "/recorded_data";
-    std::ofstream raw_csv;
 
     /**
      * @brief Wrapper object protecting the lifetime of IMU integration inputs and biases
@@ -189,10 +177,12 @@ private:
         }
 
         assert(_pim_obj != nullptr && "_pim_obj should not be null");
-        std::cout << "CAM to IMU offset is " << input_values->t_offset.count() << std::endl;
 
-        time_point time_begin = input_values->last_cam_integration_time + input_values->t_offset;
-        time_point time_end   = input_values->t_offset + real_time;
+        // TODO last_imu_offset is 0, t_offset only take effects when it's negative. 
+        // However, why would we want to integrate to a past time point rather than the current time point?
+        time_point time_begin = input_values->last_cam_integration_time + last_imu_offset;
+        // time_point time_end   = input_values->t_offset + real_time;
+        time_point time_end   = real_time;
 
         const std::vector<imu_type> prop_data = select_imu_readings(_imu_vec, time_begin, time_end);
 
@@ -205,9 +195,9 @@ private:
         ImuBias prev_bias = _pim_obj->biasHat();
         ImuBias bias      = _pim_obj->biasHat();
 
-// #ifndef NDEBUG
+#ifndef NDEBUG
         std::cout << "Integrating over " << prop_data.size() << " IMU samples\n";
-// #endif
+#endif
 
         for (std::size_t i = 0; i < prop_data.size() - 1; i++) {
             _pim_obj->integrateMeasurement(prop_data[i], prop_data[i + 1]);
@@ -232,14 +222,6 @@ private:
                                                                       navstate_k.velocity(),              /// Velocity
                                                                       out_pose.rotation().toQuaternion(), /// Eigen Quat
                                                                       real_time}));
-        raw_csv << std::fixed << real_time.time_since_epoch().count() << ","
-                << out_pose.x() << ","
-                << out_pose.y() << ","
-                << out_pose.z() << ","
-                << out_pose.rotation().toQuaternion().w() << ","
-                << out_pose.rotation().toQuaternion().x() << ","
-                << out_pose.rotation().toQuaternion().y() << ","
-                << out_pose.rotation().toQuaternion().z() << std::endl;
     }
 
     // Select IMU readings based on timestamp similar to how OpenVINS selects IMU values to propagate

--- a/record_imu_cam/plugin.cpp
+++ b/record_imu_cam/plugin.cpp
@@ -54,10 +54,8 @@ public:
         Eigen::Vector3d linear_a  = datum->linear_a;
 
         // write imu0
-        imu_wt_file << timestamp << "," << std::setprecision(17)
-                    << angular_v[0] << "," << angular_v[1] << "," << angular_v[2] << ","
-                    << linear_a[0] << "," << linear_a[1] << "," << linear_a[2]
-                    << std::endl;
+        imu_wt_file << timestamp << "," << std::setprecision(17) << angular_v[0] << "," << angular_v[1] << "," << angular_v[2]
+                    << "," << linear_a[0] << "," << linear_a[1] << "," << linear_a[2] << std::endl;
 
         // write cam0 and cam1
         switchboard::ptr<const cam_type> cam;

--- a/record_imu_cam/plugin.cpp
+++ b/record_imu_cam/plugin.cpp
@@ -54,8 +54,10 @@ public:
         Eigen::Vector3d linear_a  = datum->linear_a;
 
         // write imu0
-        imu_wt_file << timestamp << "," << std::setprecision(17) << angular_v[0] << "," << angular_v[1] << "," << angular_v[2]
+        imu_wt_file << datum->time.time_since_epoch().count() << "," << std::setprecision(17) << angular_v[0] << "," << angular_v[1] << "," << angular_v[2]
                     << "," << linear_a[0] << "," << linear_a[1] << "," << linear_a[2] << std::endl;
+        // imu_wt_file << timestamp << "," << std::setprecision(17) << angular_v[0] << "," << angular_v[1] << "," << angular_v[2]
+        //             << "," << linear_a[0] << "," << linear_a[1] << "," << linear_a[2] << std::endl;
 
         // write cam0 and cam1
         switchboard::ptr<const cam_type> cam;
@@ -63,10 +65,14 @@ public:
         std::string cam0_img = cam0_data_dir.string() + "/" + std::to_string(timestamp) + ".png";
         std::string cam1_img = cam1_data_dir.string() + "/" + std::to_string(timestamp) + ".png";
         if (cam != nullptr) {
-            cam0_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
+            cam0_wt_file << cam->time.time_since_epoch().count() << "," << timestamp << ".png " << std::endl;
             cv::imwrite(cam0_img, cam->img0);
-            cam1_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
+            cam1_wt_file << cam->time.time_since_epoch().count() << "," << timestamp << ".png " << std::endl;
             cv::imwrite(cam1_img, cam->img1);
+            // cam0_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
+            // cv::imwrite(cam0_img, cam->img0);
+            // cam1_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
+            // cv::imwrite(cam1_img, cam->img1);
         }
     }
 

--- a/record_imu_cam/plugin.cpp
+++ b/record_imu_cam/plugin.cpp
@@ -54,12 +54,10 @@ public:
         Eigen::Vector3d linear_a  = datum->linear_a;
 
         // write imu0
-        imu_wt_file << datum->time.time_since_epoch().count() << "," << std::setprecision(17) << angular_v[0] << ","
-                    << angular_v[1] << "," << angular_v[2] << "," << linear_a[0] << "," << linear_a[1] << "," << linear_a[2]
+        imu_wt_file << timestamp << "," << std::setprecision(17)
+                    << angular_v[0] << "," << angular_v[1] << "," << angular_v[2] << ","
+                    << linear_a[0] << "," << linear_a[1] << "," << linear_a[2]
                     << std::endl;
-        // imu_wt_file << timestamp << "," << std::setprecision(17) << angular_v[0] << "," << angular_v[1] << "," <<
-        // angular_v[2]
-        //             << "," << linear_a[0] << "," << linear_a[1] << "," << linear_a[2] << std::endl;
 
         // write cam0 and cam1
         switchboard::ptr<const cam_type> cam;
@@ -67,14 +65,10 @@ public:
         std::string cam0_img = cam0_data_dir.string() + "/" + std::to_string(timestamp) + ".png";
         std::string cam1_img = cam1_data_dir.string() + "/" + std::to_string(timestamp) + ".png";
         if (cam != nullptr) {
-            cam0_wt_file << cam->time.time_since_epoch().count() << "," << timestamp << ".png " << std::endl;
+            cam0_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
             cv::imwrite(cam0_img, cam->img0);
-            cam1_wt_file << cam->time.time_since_epoch().count() << "," << timestamp << ".png " << std::endl;
+            cam1_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
             cv::imwrite(cam1_img, cam->img1);
-            // cam0_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
-            // cv::imwrite(cam0_img, cam->img0);
-            // cam1_wt_file << timestamp << "," << timestamp << ".png " << std::endl;
-            // cv::imwrite(cam1_img, cam->img1);
         }
     }
 

--- a/zed/src/main.cpp
+++ b/zed/src/main.cpp
@@ -15,13 +15,28 @@
 using namespace ILLIXR;
 
 // Set exposure to 8% of camera frame time. This is an empirically determined number
-static constexpr unsigned EXPOSURE_TIME_PERCENT = 12;
+static constexpr unsigned EXPOSURE_TIME_PERCENT = 8;
 
 const record_header __imu_cam_record{"imu_cam",
                                      {
                                          {"iteration_no", typeid(std::size_t)},
                                          {"has_camera", typeid(bool)},
                                      }};
+
+struct cam_type_zed : public switchboard::event {
+    cam_type_zed(cv::Mat _img0, cv::Mat _img1, cv::Mat _rgb, cv::Mat _depth, std::size_t _serial_no)
+        : img0{_img0}
+        , img1{_img1}
+        , rgb{_rgb}
+        , depth{_depth}
+        , serial_no{_serial_no} { }
+
+    cv::Mat     img0;
+    cv::Mat     img1;
+    cv::Mat     rgb;
+    cv::Mat     depth;
+    std::size_t serial_no;
+};
 
 std::shared_ptr<Camera> start_camera() {
     std::shared_ptr<Camera> zedm = std::make_shared<Camera>();
@@ -33,7 +48,7 @@ std::shared_ptr<Camera> start_camera() {
     init_params.camera_resolution      = RESOLUTION::VGA;
     init_params.coordinate_units       = UNIT::MILLIMETER;                           // For scene reconstruction
     init_params.coordinate_system      = COORDINATE_SYSTEM::RIGHT_HANDED_Z_UP_X_FWD; // Coordinate system used in ROS
-    init_params.camera_fps             = 30;
+    init_params.camera_fps             = 15;
     init_params.depth_mode             = DEPTH_MODE::PERFORMANCE;
     init_params.depth_stabilization    = true;
     init_params.depth_minimum_distance = 0.3;
@@ -44,7 +59,6 @@ std::shared_ptr<Camera> start_camera() {
         printf("%s\n", toString(err).c_str());
         zedm->close();
     }
-    std::cout << "ZED started\n";
 
     zedm->setCameraSettings(VIDEO_SETTINGS::EXPOSURE, EXPOSURE_TIME_PERCENT);
 
@@ -57,8 +71,7 @@ public:
         : threadloop{name_, pb_}
         , sb{pb->lookup_impl<switchboard>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
-        , _m_cam{sb->get_writer<cam_type>("cam")}
-        , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")}
+        , _m_cam{sb->get_writer<cam_type_zed>("cam_zed")}
         , zedm{zedm_}
         , image_size{zedm->getCameraInformation().camera_configuration.resolution} {
         // runtime_parameters.sensing_mode = SENSING_MODE::STANDARD;
@@ -74,15 +87,10 @@ public:
         depth_ocv  = slMat2cvMat(depth_zed);
     }
 
-    void set_first_time(ullong imu_first_time) {
-        _m_first_imu_time = imu_first_time;
-    }
-
 private:
     const std::shared_ptr<switchboard>         sb;
     const std::shared_ptr<const RelativeClock> _m_clock;
-    switchboard::writer<cam_type>              _m_cam;
-    switchboard::writer<rgb_depth_type>        _m_rgb_depth;
+    switchboard::writer<cam_type_zed>          _m_cam;
     std::shared_ptr<Camera>                    zedm;
     Resolution                                 image_size;
     RuntimeParameters                          runtime_parameters;
@@ -98,8 +106,6 @@ private:
     cv::Mat depth_ocv;
     cv::Mat rgb_ocv;
 
-    // std::optional<ullong>     _m_first_cam_time;
-    // std::optional<time_point> _m_first_real_time;
     std::optional<ullong> _m_first_imu_time;
 
 protected:
@@ -117,30 +123,13 @@ protected:
         // Time as ullong (nanoseconds)
         ullong cam_time = static_cast<ullong>(zedm->getTimestamp(TIME_REFERENCE::IMAGE).getNanoseconds());
 
-        // Time as time_point
-        // if (!_m_first_cam_time) {
-        //     _m_first_cam_time  = cam_time;
-        //     _m_first_real_time = _m_clock->now();
-        // }
-        // time_point cam_time_point{std::chrono::nanoseconds(cam_time - *_m_first_cam_time)};
-        
-        // We align the starting time point of IMU and CAM to be the first IMU time
-        if (!_m_first_imu_time || cam_time < _m_first_imu_time) {
-            return;
-        }
-        time_point cam_time_point{std::chrono::nanoseconds(cam_time - *_m_first_imu_time)};
-        std::this_thread::sleep_for(std::chrono::nanoseconds{cam_time - *_m_first_imu_time} -
-                                        _m_clock->now().time_since_epoch());
-
         // Retrieve images
         zedm->retrieveImage(imageL_zed, VIEW::LEFT_GRAY, MEM::CPU, image_size);
         zedm->retrieveImage(imageR_zed, VIEW::RIGHT_GRAY, MEM::CPU, image_size);
         zedm->retrieveMeasure(depth_zed, MEASURE::DEPTH, MEM::CPU, image_size);
         zedm->retrieveImage(rgb_zed, VIEW::LEFT, MEM::CPU, image_size);
 
-        _m_cam.put(_m_cam.allocate<cam_type>({cam_time_point, cv::Mat{imageL_ocv}, cv::Mat{imageR_ocv}}));
-
-        _m_rgb_depth.put(_m_rgb_depth.allocate<rgb_depth_type>({cam_time_point, cv::Mat{rgb_ocv}, cv::Mat{depth_ocv}}));
+        _m_cam.put(_m_cam.allocate<cam_type_zed>({cv::Mat{imageL_ocv}, cv::Mat{imageR_ocv}, cv::Mat{rgb_ocv}, cv::Mat{depth_ocv}, ++serial_no}));
 
         RAC_ERRNO_MSG("zed_cam at end of _p_one_iteration");
     }
@@ -158,6 +147,9 @@ public:
         , sb{pb->lookup_impl<switchboard>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , _m_imu{sb->get_writer<imu_type>("imu")}
+        , _m_cam_reader{sb->get_reader<cam_type_zed>("cam_zed")}
+        , _m_cam_publisher{sb->get_writer<cam_type>("cam")}
+        , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")}
         , zedm{start_camera()}
         , camera_thread_{"zed_camera_thread", pb_, zedm}
         , it_log{record_logger_} {
@@ -173,7 +165,7 @@ protected:
     virtual skip_option _p_should_skip() override {
         zedm->getSensorsData(sensors_data, TIME_REFERENCE::CURRENT);
         if (sensors_data.imu.timestamp > last_imu_ts) {
-            // std::this_thread::sleep_for(std::chrono::milliseconds{2});
+            std::this_thread::sleep_for(std::chrono::milliseconds{2});
             return skip_option::run;
         } else {
             return skip_option::skip_and_yield;
@@ -183,7 +175,7 @@ protected:
     virtual void _p_one_iteration() override {
         RAC_ERRNO_MSG("zed at start of _p_one_iteration");
 
-        std::cout << "IMU Rate: " << sensors_data.imu.effective_rate << "\n" << std::endl;
+        // std::cout << "IMU Rate: " << sensors_data.imu.effective_rate << "\n" << std::endl;
 
         // Time as ullong (nanoseconds)
         ullong imu_time = static_cast<ullong>(sensors_data.imu.timestamp.getNanoseconds());
@@ -191,7 +183,6 @@ protected:
         // Time as time_point
         if (!_m_first_imu_time) {
             _m_first_imu_time  = imu_time;
-            camera_thread_.set_first_time(_m_first_imu_time.value());
             _m_first_real_time = _m_clock->now();
         }
         time_point imu_time_point{std::chrono::nanoseconds(imu_time - *_m_first_imu_time)};
@@ -208,6 +199,13 @@ protected:
 
         _m_imu.put(_m_imu.allocate<imu_type>({imu_time_point, av.cast<double>(), la.cast<double>()}));
 
+        switchboard::ptr<const cam_type_zed> c = _m_cam_reader.get_ro_nullable();
+        if (c && c->serial_no != last_serial_no) {
+            _m_cam_publisher.put(_m_cam_publisher.allocate<cam_type>({imu_time_point, cv::Mat{c->img0}, cv::Mat{c->img1}}));
+            _m_rgb_depth.put(_m_rgb_depth.allocate<rgb_depth_type>({imu_time_point, cv::Mat{c->rgb}, cv::Mat{c->depth}}));
+            last_serial_no = c->serial_no;
+        }
+
         last_imu_ts = sensors_data.imu.timestamp;
 
         RAC_ERRNO_MSG("zed_imu at end of _p_one_iteration");
@@ -220,10 +218,14 @@ private:
     const std::shared_ptr<switchboard>         sb;
     const std::shared_ptr<const RelativeClock> _m_clock;
     switchboard::writer<imu_type>              _m_imu;
+    switchboard::reader<cam_type_zed> _m_cam_reader;
+    switchboard::writer<cam_type>     _m_cam_publisher;
+    switchboard::writer<rgb_depth_type>        _m_rgb_depth;
 
     // IMU
     SensorsData sensors_data;
     Timestamp   last_imu_ts = 0;
+    std::size_t last_serial_no = 0;
 
     // Logger
     record_coalescer it_log;

--- a/zed/src/main.cpp
+++ b/zed/src/main.cpp
@@ -129,7 +129,7 @@ protected:
         zedm->retrieveMeasure(depth_zed, MEASURE::DEPTH, MEM::CPU, image_size);
         zedm->retrieveImage(rgb_zed, VIEW::LEFT, MEM::CPU, image_size);
 
-        _m_cam.put(_m_cam.allocate<cam_type_zed>({cv::Mat{imageL_ocv}, cv::Mat{imageR_ocv}, cv::Mat{rgb_ocv}, cv::Mat{depth_ocv}, ++serial_no}));
+        _m_cam.put(_m_cam.allocate<cam_type_zed>({cv::Mat{imageL_ocv.clone()}, cv::Mat{imageR_ocv.clone()}, cv::Mat{rgb_ocv.clone()}, cv::Mat{depth_ocv.clone()}, ++serial_no}));
 
         RAC_ERRNO_MSG("zed_cam at end of _p_one_iteration");
     }
@@ -185,9 +185,9 @@ protected:
             _m_first_imu_time  = imu_time;
             _m_first_real_time = _m_clock->now();
         }
-        time_point imu_time_point{std::chrono::nanoseconds(imu_time - *_m_first_imu_time)};
-        std::this_thread::sleep_for(std::chrono::nanoseconds{imu_time - *_m_first_imu_time} -
-                                        _m_clock->now().time_since_epoch());
+        // _m_first_real_time is the time point when the system receives the first IMU sample
+        // Timestamp for later IMU samples is its dataset time difference from the first sample added to _m_first_real_time
+        time_point imu_time_point{*_m_first_real_time + std::chrono::nanoseconds(imu_time - *_m_first_imu_time)};
 
         // Linear Acceleration and Angular Velocity (av converted from deg/s to rad/s)
         Eigen::Vector3f la = {sensors_data.imu.linear_acceleration_uncalibrated.x,

--- a/zed/src/main.cpp
+++ b/zed/src/main.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<Camera> start_camera() {
     init_params.camera_resolution      = RESOLUTION::VGA;
     init_params.coordinate_units       = UNIT::MILLIMETER;                           // For scene reconstruction
     init_params.coordinate_system      = COORDINATE_SYSTEM::RIGHT_HANDED_Z_UP_X_FWD; // Coordinate system used in ROS
-    init_params.camera_fps             = 15;
+    init_params.camera_fps             = 30;                                         // gives best user experience
     init_params.depth_mode             = DEPTH_MODE::PERFORMANCE;
     init_params.depth_stabilization    = true;
     init_params.depth_minimum_distance = 0.3;

--- a/zed/src/main.cpp
+++ b/zed/src/main.cpp
@@ -129,7 +129,8 @@ protected:
         zedm->retrieveMeasure(depth_zed, MEASURE::DEPTH, MEM::CPU, image_size);
         zedm->retrieveImage(rgb_zed, VIEW::LEFT, MEM::CPU, image_size);
 
-        _m_cam.put(_m_cam.allocate<cam_type_zed>({cv::Mat{imageL_ocv.clone()}, cv::Mat{imageR_ocv.clone()}, cv::Mat{rgb_ocv.clone()}, cv::Mat{depth_ocv.clone()}, ++serial_no}));
+        _m_cam.put(_m_cam.allocate<cam_type_zed>({cv::Mat{imageL_ocv.clone()}, cv::Mat{imageR_ocv.clone()},
+                                                  cv::Mat{rgb_ocv.clone()}, cv::Mat{depth_ocv.clone()}, ++serial_no}));
 
         RAC_ERRNO_MSG("zed_cam at end of _p_one_iteration");
     }


### PR DESCRIPTION
Fix the shaking issue with ZED after separating the imu and camera. 

The changes concern the follows:

- How to set IMU and camera timestamps in ZED plugin. Previously (before separating IMU and camera) all camera images were given the timestamp of the nearest IMU sample. This helps making sure that IMU and Camera streams are on the same time frame and share the same starting time point, but the camera timestamps are then skewed. I wonder if there's any downstream functions (OpenVINS for e.g.) that require all camera images having corresponding IMU sample? 
- The use of cam_to_imu time offset in IMU integrator. The old implementation applies a zero offset to the starting point of the integration and a OpenVINS estimated offset to the ending point. The offset will only take effects on the ending point if it's negative because the IMU samples for future timestamps are not available. But why would we want to integrate to a past time point rather than the current time point?

Please test with the [fix-zed branch](https://github.com/ILLIXR/open_vins/tree/fix-zed) of OpenVINS.