### PR TITLE
Add spdlogger cmake option (#425)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(DATA_FILE "http://robotics.ethz.ch/~asl-datasets/ijrr_euroc_mav_dataset/vico
 
 option(BUILD_DOCS "Build documentation" OFF)
 option(USE_MONADO "Build for monado use" OFF)
+option(USE_SPDLOGGER "Build with spdlogger enabled" OFF)
 include(cmake/HelperFunctions.cmake)
 
 set(VISUALIZER "" CACHE STRING "")
@@ -186,7 +187,10 @@ find_package(Git REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS filesystem serialization)
 
-find_package(spdlog REQUIRED)
+if(USE_SPDLOGGER)
+    add_definitions(-DUSE_SPDLOGGER)
+    find_package(spdlog REQUIRED)
+endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)

--- a/cmake/ConfigurationSummary.cmake
+++ b/cmake/ConfigurationSummary.cmake
@@ -288,6 +288,7 @@ report_value("Library suffix" "${ILLIXR_BUILD_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFF
 report_value("C compilation flags" "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
 report_value("C++ compilation flags" "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}")
 report_value("Install location" "${CMAKE_INSTALL_PREFIX}")
+report_value("Using spdlog library" "${USE_SPDLOGGER}")
 
 # ------------------------- External Libraries ---------------------------------
 message("${COLOR_BLUE_BOLD}External Libraries${RESET_FORMAT}")

--- a/include/illixr/concurrentqueue/queue.hpp
+++ b/include/illixr/concurrentqueue/queue.hpp
@@ -1,10 +1,13 @@
 #include <chrono>
 #include <mutex>
 #include <list>
+#include <thread>
+
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
 #include <spdlog/spdlog.h>
 #endif
-#include <thread>
+#endif
 
 namespace moodycamel {
 	template <typename T>
@@ -17,7 +20,9 @@ namespace moodycamel {
 
 		bool try_dequeue(T& elem) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[queue] try_dequeue");
+#endif
 #endif
 			std::lock_guard{mut};
 			if (!list.empty()) {
@@ -29,7 +34,9 @@ namespace moodycamel {
 		}
 
 		bool wait_dequeue_timed(T& elem, size_t usecs_) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[queue] wait_dequeue_timed");
+#endif
 			std::chrono::microseconds usecs {usecs_};
 			auto start = std::chrono::system_clock::now();
 			while (std::chrono::system_clock::now() < start + usecs) {
@@ -42,7 +49,9 @@ namespace moodycamel {
 		}
 
 		bool enqueue(T&& elem) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[queue] enqueue");
+#endif
 			std::lock_guard{mut};
 			list.emplace_back(elem);
 			return true;

--- a/include/illixr/cpu_timer.hpp
+++ b/include/illixr/cpu_timer.hpp
@@ -8,10 +8,13 @@
 #include <cstring>
 #include <functional>
 #include <iostream>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <thread>
 #include <utility>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 /**
  * @brief A C++ translation of [clock_gettime][1]
@@ -126,7 +129,9 @@ private:
             // os << "cpu_timer," << _p_account_name << "," << count_duration<duration>(_p_duration) << "\n";
             if (rand() % 100 == 0) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->info("cpu_timer.hpp is DEPRECATED. See logging.hpp.");
+#endif
 #endif
             }
         }
@@ -196,8 +201,10 @@ public:
                                       std::chrono::high_resolution_clock::now().time_since_epoch())
                                       .count();
 
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->info("[cpu_timer]  cpu_timer,{},{},{},{},{},{}", name, serial_no, wall_time_start,
                                         wall_time_stop, cpu_time_start, cpu_time_stop);
+#endif
         }
     }
 };

--- a/include/illixr/cpu_timer.hpp
+++ b/include/illixr/cpu_timer.hpp
@@ -13,7 +13,7 @@
 #include <utility>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 /**
@@ -129,9 +129,9 @@ private:
             // os << "cpu_timer," << _p_account_name << "," << count_duration<duration>(_p_duration) << "\n";
             if (rand() % 100 == 0) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->info("cpu_timer.hpp is DEPRECATED. See logging.hpp.");
-#endif
+    #endif
 #endif
             }
         }

--- a/include/illixr/dynamic_lib.hpp
+++ b/include/illixr/dynamic_lib.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 namespace ILLIXR {
@@ -47,12 +47,12 @@ public:
 
     ~dynamic_lib() {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         if (!_m_lib_path.empty()) {
             spdlog::get("illixr")->debug("[dynamic_lib] Destructing library : {}", _m_lib_path);
         }
-#endif /// USE_SPDLOGGER
-#endif /// NDEBUG
+    #endif /// USE_SPDLOGGER
+#endif     /// NDEBUG
     }
 
     static dynamic_lib create(const std::string& path) {

--- a/include/illixr/dynamic_lib.hpp
+++ b/include/illixr/dynamic_lib.hpp
@@ -6,9 +6,12 @@
 #include <functional>
 #include <iostream>
 #include <memory>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <utility>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 namespace ILLIXR {
 
@@ -44,9 +47,11 @@ public:
 
     ~dynamic_lib() {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         if (!_m_lib_path.empty()) {
             spdlog::get("illixr")->debug("[dynamic_lib] Destructing library : {}", _m_lib_path);
         }
+#endif /// USE_SPDLOGGER
 #endif /// NDEBUG
     }
 
@@ -76,7 +81,9 @@ public:
                          int   ret = dlclose(handle);
                          if ((error = dlerror()) || ret) {
                              const std::string msg_error{"dlclose(): " + (error == nullptr ? "NULL" : std::string{error})};
+#ifdef USE_SPDLOGGER
                              spdlog::get("illixr")->error("[dynamic_lib] {}", msg_error);
+#endif
                              throw std::runtime_error{msg_error};
                          }
                      }},

--- a/include/illixr/error_util.hpp
+++ b/include/illixr/error_util.hpp
@@ -7,8 +7,11 @@
 #include "global_module_defs.hpp"
 
 #include <iostream>
-#include <spdlog/spdlog.h>
 #include <string>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 /**
  * @brief Parameterless macro for report_and_clear_errno.
@@ -42,10 +45,12 @@ inline void report_and_clear_errno([[maybe_unused]] const std::string& file, [[m
 #ifndef NDEBUG
     if (errno > 0) {
         if (ILLIXR::ENABLE_VERBOSE_ERRORS) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[error_util] || Errno was set: {} @ {}:{} [{}]", errno, file, line, function);
             if (!msg.empty()) {
                 spdlog::get("illixr")->error("[error_util]|> Message: {}", msg);
             }
+#endif
         }
         errno = 0;
     }
@@ -59,7 +64,9 @@ inline void report_and_clear_errno([[maybe_unused]] const std::string& file, [[m
  * SIGABRT for debugging.
  */
 inline void abort(const std::string& msg = "", [[maybe_unused]] const int error_val = 1) {
+#ifdef USE_SPDLOGGER
     spdlog::get("illixr")->error("[error_util] ** ERROR ** {}", msg);
+#endif
 #ifndef NDEBUG
     std::abort();
 #else  /// NDEBUG

--- a/include/illixr/error_util.hpp
+++ b/include/illixr/error_util.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 /**
@@ -45,12 +45,12 @@ inline void report_and_clear_errno([[maybe_unused]] const std::string& file, [[m
 #ifndef NDEBUG
     if (errno > 0) {
         if (ILLIXR::ENABLE_VERBOSE_ERRORS) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[error_util] || Errno was set: {} @ {}:{} [{}]", errno, file, line, function);
             if (!msg.empty()) {
                 spdlog::get("illixr")->error("[error_util]|> Message: {}", msg);
             }
-#endif
+    #endif
         }
         errno = 0;
     }

--- a/include/illixr/extended_window.hpp
+++ b/include/illixr/extended_window.hpp
@@ -9,9 +9,9 @@
 #include <GL/glx.h>
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
-    #include <spdlog/spdlog.h>
-#endif
+    #ifdef USE_SPDLOGGER
+        #include <spdlog/spdlog.h>
+    #endif
 #endif
 
 // GLX context magics
@@ -33,9 +33,9 @@ public:
         height = _height;
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Opening display");
-#endif
+    #endif
 #endif
         RAC_ERRNO_MSG("extended_window at start of xlib_gl_extended_window constructor");
 
@@ -78,9 +78,9 @@ public:
                                        None};
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Getting matching framebuffer configs");
-#endif
+    #endif
 #endif
         RAC_ERRNO_MSG("extended_window before glXChooseFBConfig");
 
@@ -92,10 +92,10 @@ public:
         }
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Found {} matching FB configs", fbcount);
         spdlog::get("illixr")->debug("[extended_window] Getting XVisualInfos");
-#endif
+    #endif
 #endif
         // Pick the FB config/visual with the most samples per pixel
         int best_fbc = -1, worst_fbc = -1, best_num_samp = -1, worst_num_samp = 999;
@@ -107,11 +107,11 @@ public:
                 glXGetFBConfigAttrib(dpy, fbc[i], GLX_SAMPLE_BUFFERS, &samp_buf);
                 glXGetFBConfigAttrib(dpy, fbc[i], GLX_SAMPLES, &samples);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->debug(
                     "[extended_window] Matching fbconfig {}, visual ID {:x}: SAMPLE_BUFFERS = {}, SAMPLES = {}", i,
                     vi->visualid, samp_buf, samples);
-#endif
+    #endif
 #endif
                 if (best_fbc < 0 || (samp_buf && samples > best_num_samp)) {
                     best_fbc = i, best_num_samp = samples;
@@ -132,17 +132,17 @@ public:
         // Get a visual
         XVisualInfo* vi = glXGetVisualFromFBConfig(dpy, bestFbc);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Chose visual ID = {:x}", vi->visualid);
         spdlog::get("illixr")->debug("[extended_window] Creating colormap");
-#endif
+    #endif
 #endif
         _m_cmap = XCreateColormap(dpy, root, vi->visual, AllocNone);
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Creating window");
-#endif
+    #endif
 #endif
         XSetWindowAttributes attributes;
         attributes.colormap         = _m_cmap;
@@ -161,9 +161,9 @@ public:
         XFree(vi);
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Creating context");
-#endif
+    #endif
 #endif
         auto glXCreateContextAttribsARB =
             (glXCreateContextAttribsARBProc) glXGetProcAddressARB((const GLubyte*) "glXCreateContextAttribsARB");

--- a/include/illixr/extended_window.hpp
+++ b/include/illixr/extended_window.hpp
@@ -7,8 +7,11 @@
 #include <cassert>
 #include <cerrno>
 #include <GL/glx.h>
+
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
     #include <spdlog/spdlog.h>
+#endif
 #endif
 
 // GLX context magics
@@ -30,7 +33,9 @@ public:
         height = _height;
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Opening display");
+#endif
 #endif
         RAC_ERRNO_MSG("extended_window at start of xlib_gl_extended_window constructor");
 
@@ -73,7 +78,9 @@ public:
                                        None};
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Getting matching framebuffer configs");
+#endif
 #endif
         RAC_ERRNO_MSG("extended_window before glXChooseFBConfig");
 
@@ -85,11 +92,12 @@ public:
         }
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Found {} matching FB configs", fbcount);
-
-        // Pick the FB config/visual with the most samples per pixel
         spdlog::get("illixr")->debug("[extended_window] Getting XVisualInfos");
 #endif
+#endif
+        // Pick the FB config/visual with the most samples per pixel
         int best_fbc = -1, worst_fbc = -1, best_num_samp = -1, worst_num_samp = 999;
         int i;
         for (i = 0; i < fbcount; ++i) {
@@ -99,9 +107,11 @@ public:
                 glXGetFBConfigAttrib(dpy, fbc[i], GLX_SAMPLE_BUFFERS, &samp_buf);
                 glXGetFBConfigAttrib(dpy, fbc[i], GLX_SAMPLES, &samples);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->debug(
                     "[extended_window] Matching fbconfig {}, visual ID {:x}: SAMPLE_BUFFERS = {}, SAMPLES = {}", i,
                     vi->visualid, samp_buf, samples);
+#endif
 #endif
                 if (best_fbc < 0 || (samp_buf && samples > best_num_samp)) {
                     best_fbc = i, best_num_samp = samples;
@@ -122,13 +132,17 @@ public:
         // Get a visual
         XVisualInfo* vi = glXGetVisualFromFBConfig(dpy, bestFbc);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Chose visual ID = {:x}", vi->visualid);
         spdlog::get("illixr")->debug("[extended_window] Creating colormap");
+#endif
 #endif
         _m_cmap = XCreateColormap(dpy, root, vi->visual, AllocNone);
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Creating window");
+#endif
 #endif
         XSetWindowAttributes attributes;
         attributes.colormap         = _m_cmap;
@@ -147,7 +161,9 @@ public:
         XFree(vi);
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[extended_window] Creating context");
+#endif
 #endif
         auto glXCreateContextAttribsARB =
             (glXCreateContextAttribsARBProc) glXGetProcAddressARB((const GLubyte*) "glXCreateContextAttribsARB");

--- a/include/illixr/gl_util/obj.hpp
+++ b/include/illixr/gl_util/obj.hpp
@@ -3,7 +3,7 @@
 #include "../error_util.hpp"
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 #define TINYOBJLOADER_IMPLEMENTATION
@@ -87,9 +87,9 @@ public:
         bool success = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, obj_file.c_str(), obj_dir_term.c_str());
         if (!warn.empty()) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->warn("[obj] {}", warn);
-#endif
+    #endif
 #endif
         }
         if (!err.empty()) {
@@ -111,10 +111,10 @@ public:
             for (size_t mat_idx = 0; mat_idx < materials.size(); mat_idx++) {
                 tinyobj::material_t* mp = &materials[mat_idx];
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->debug("[obj] Loading material named: {}", materials[mat_idx].name);
                 spdlog::get("illixr")->debug("[obj] Material texture name: {}", materials[mat_idx].diffuse_texname);
-#endif
+    #endif
 #endif
                 if (mp->diffuse_texname.length() > 0) {
                     // If we haven't loaded the texture yet...
@@ -126,16 +126,16 @@ public:
 
                         if (texture_data == nullptr) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                             spdlog::get("illixr")->warn("[obj TEXTURE] Loading of {} failed.", filename);
-#endif
+    #endif
 #endif
                             successfully_loaded_texture = false;
                         } else {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                             spdlog::get("illixr")->debug("[obj TEXTURE] Loaded  {}: Resolution ({}, {})", filename, x, y);
-#endif
+    #endif
 #endif
                             GLuint texture_handle;
 
@@ -173,10 +173,10 @@ public:
             // Iterate over "shapes" (objects in .obj file)
             for (size_t shape_idx = 0; shape_idx < shapes.size(); shape_idx++) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->debug("[obj] Num verts in shape: {}", shapes[shape_idx].mesh.indices.size());
                 spdlog::get("illixr")->debug("[obj] Num tris in shape: {}", shapes[shape_idx].mesh.indices.size() / 3);
-#endif
+    #endif
 #endif
                 // Unified buffer for pos + uv. Interleaving vertex data (good practice!)
                 std::vector<vertex_t> buffer;

--- a/include/illixr/gl_util/obj.hpp
+++ b/include/illixr/gl_util/obj.hpp
@@ -2,7 +2,9 @@
 
 #include "../error_util.hpp"
 
+#ifdef USE_SPDLOGGER
 #include <spdlog/spdlog.h>
+#endif
 
 #define TINYOBJLOADER_IMPLEMENTATION
 #include "lib/tiny_obj_loader.h"
@@ -85,17 +87,22 @@ public:
         bool success = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, obj_file.c_str(), obj_dir_term.c_str());
         if (!warn.empty()) {
 #ifndef NDEBUG
-
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->warn("[obj] {}", warn);
+#endif
 #endif
         }
         if (!err.empty()) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[obj] {}", err);
+#endif
             successfully_loaded_model = false;
             ILLIXR::abort();
         }
         if (!success) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[obj] Loading of {} failed.", obj_filename);
+#endif
             successfully_loaded_model = false;
             ILLIXR::abort();
         } else {
@@ -104,8 +111,10 @@ public:
             for (size_t mat_idx = 0; mat_idx < materials.size(); mat_idx++) {
                 tinyobj::material_t* mp = &materials[mat_idx];
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->debug("[obj] Loading material named: {}", materials[mat_idx].name);
                 spdlog::get("illixr")->debug("[obj] Material texture name: {}", materials[mat_idx].diffuse_texname);
+#endif
 #endif
                 if (mp->diffuse_texname.length() > 0) {
                     // If we haven't loaded the texture yet...
@@ -117,12 +126,16 @@ public:
 
                         if (texture_data == nullptr) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                             spdlog::get("illixr")->warn("[obj TEXTURE] Loading of {} failed.", filename);
+#endif
 #endif
                             successfully_loaded_texture = false;
                         } else {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                             spdlog::get("illixr")->debug("[obj TEXTURE] Loaded  {}: Resolution ({}, {})", filename, x, y);
+#endif
 #endif
                             GLuint texture_handle;
 
@@ -160,8 +173,10 @@ public:
             // Iterate over "shapes" (objects in .obj file)
             for (size_t shape_idx = 0; shape_idx < shapes.size(); shape_idx++) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->debug("[obj] Num verts in shape: {}", shapes[shape_idx].mesh.indices.size());
                 spdlog::get("illixr")->debug("[obj] Num tris in shape: {}", shapes[shape_idx].mesh.indices.size() / 3);
+#endif
 #endif
                 // Unified buffer for pos + uv. Interleaving vertex data (good practice!)
                 std::vector<vertex_t> buffer;

--- a/include/illixr/phonebook.hpp
+++ b/include/illixr/phonebook.hpp
@@ -9,8 +9,13 @@
 
 #ifndef NDEBUG
     #include <iostream>
-    #include <spdlog/spdlog.h>
     #include <stdexcept>
+#endif
+
+#ifndef NDEBUG
+#ifdef USE_SPDLOGGER
+    #include <spdlog/spdlog.h>
+#endif
 #endif
 
 namespace ILLIXR {
@@ -103,7 +108,9 @@ public:
 
         const std::type_index type_index = std::type_index(typeid(specific_service));
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[phonebook] Register {}", type_index.name());
+#endif
 #endif
         assert(_m_registry.count(type_index) == 0);
         _m_registry.try_emplace(type_index, impl);

--- a/include/illixr/phonebook.hpp
+++ b/include/illixr/phonebook.hpp
@@ -13,9 +13,9 @@
 #endif
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
-    #include <spdlog/spdlog.h>
-#endif
+    #ifdef USE_SPDLOGGER
+        #include <spdlog/spdlog.h>
+    #endif
 #endif
 
 namespace ILLIXR {
@@ -108,9 +108,9 @@ public:
 
         const std::type_index type_index = std::type_index(typeid(specific_service));
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[phonebook] Register {}", type_index.name());
-#endif
+    #endif
 #endif
         assert(_m_registry.count(type_index) == 0);
         _m_registry.try_emplace(type_index, impl);

--- a/include/illixr/plugin.hpp
+++ b/include/illixr/plugin.hpp
@@ -1,12 +1,15 @@
 #pragma once
 #include "phonebook.hpp"
 #include "record_logger.hpp"
+
+#ifdef USE_SPDLOGGER
 #include "spdlog/common.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
+#include <spdlog/spdlog.h>
+#endif
 
 #include <memory>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <typeinfo>
 #include <utility>
@@ -73,6 +76,7 @@ public:
         return name;
     }
 
+#ifdef USE_SPDLOGGER
     void spdlogger(const char* log_level) {
         if (!log_level) {
 #ifdef NDEBUG
@@ -90,6 +94,7 @@ public:
         plugin_logger->set_level(spdlog::level::from_str(log_level));
         spdlog::register_logger(plugin_logger);
     }
+#endif
 
 protected:
     std::string                          name;

--- a/include/illixr/plugin.hpp
+++ b/include/illixr/plugin.hpp
@@ -3,10 +3,11 @@
 #include "record_logger.hpp"
 
 #ifdef USE_SPDLOGGER
-#include "spdlog/common.h"
-#include "spdlog/sinks/basic_file_sink.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
-#include <spdlog/spdlog.h>
+    #include "spdlog/common.h"
+    #include "spdlog/sinks/basic_file_sink.h"
+    #include "spdlog/sinks/stdout_color_sinks.h"
+
+    #include <spdlog/spdlog.h>
 #endif
 
 #include <memory>
@@ -79,11 +80,11 @@ public:
 #ifdef USE_SPDLOGGER
     void spdlogger(const char* log_level) {
         if (!log_level) {
-#ifdef NDEBUG
+    #ifdef NDEBUG
             log_level = "warn";
-#else
+    #else
             log_level = "debug";
-#endif
+    #endif
         }
         std::vector<spdlog::sink_ptr> sinks;
         auto                          file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/" + name + ".log");

--- a/include/illixr/record_logger.hpp
+++ b/include/illixr/record_logger.hpp
@@ -6,11 +6,14 @@
 #include <chrono>
 #include <memory>
 #include <optional>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 #ifndef NDEBUG
     #include <iostream>
@@ -149,16 +152,20 @@ public:
 #ifndef NDEBUG
         assert(rh);
         if (values.size() != rh->get().get_columns()) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[record_logger] {} elements passed, but rh for {} only specifies {}.", values.size(),
                                          rh->get().get_name(), rh->get().get_columns());
+#endif
             abort();
         }
         for (std::size_t column = 0; column < values.size(); ++column) {
             if (values[column].type() != rh->get().get_column_type(column)) {
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->error("[record_logger] Caller got wrong type for column {} of {}.", column,
                                              rh->get().get_name());
                 spdlog::get("illixr")->error("[record_logger] Caller passed: {}; record_header specifies: {}",
                                              values[column].type().name(), rh->get().get_column_type(column).name());
+#endif
                 abort();
             }
         }
@@ -170,7 +177,9 @@ public:
     ~record() {
 #ifndef NDEBUG
         if (rh && !data_use_indicator_.is_used()) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[record_logger] Record was deleted without being logged.");
+#endif
             abort();
         }
 #endif
@@ -331,8 +340,10 @@ public:
 #ifndef NDEBUG
             if (&r.get_record_header() != &buffer[0].get_record_header() &&
                 r.get_record_header() == buffer[0].get_record_header()) {
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->error("[record_logger] Tried to push a record of type {} to a record logger for type {}",
                                              r.get_record_header().to_string(), buffer[0].get_record_header().to_string());
+#endif
                 abort();
             }
 #endif

--- a/include/illixr/record_logger.hpp
+++ b/include/illixr/record_logger.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 #ifndef NDEBUG
@@ -152,20 +152,20 @@ public:
 #ifndef NDEBUG
         assert(rh);
         if (values.size() != rh->get().get_columns()) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[record_logger] {} elements passed, but rh for {} only specifies {}.", values.size(),
                                          rh->get().get_name(), rh->get().get_columns());
-#endif
+    #endif
             abort();
         }
         for (std::size_t column = 0; column < values.size(); ++column) {
             if (values[column].type() != rh->get().get_column_type(column)) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->error("[record_logger] Caller got wrong type for column {} of {}.", column,
                                              rh->get().get_name());
                 spdlog::get("illixr")->error("[record_logger] Caller passed: {}; record_header specifies: {}",
                                              values[column].type().name(), rh->get().get_column_type(column).name());
-#endif
+    #endif
                 abort();
             }
         }
@@ -177,9 +177,9 @@ public:
     ~record() {
 #ifndef NDEBUG
         if (rh && !data_use_indicator_.is_used()) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->error("[record_logger] Record was deleted without being logged.");
-#endif
+    #endif
             abort();
         }
 #endif
@@ -340,10 +340,10 @@ public:
 #ifndef NDEBUG
             if (&r.get_record_header() != &buffer[0].get_record_header() &&
                 r.get_record_header() == buffer[0].get_record_header()) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->error("[record_logger] Tried to push a record of type {} to a record logger for type {}",
                                              r.get_record_header().to_string(), buffer[0].get_record_header().to_string());
-#endif
+    #endif
                 abort();
             }
 #endif

--- a/include/illixr/shader_util.hpp
+++ b/include/illixr/shader_util.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 using namespace ILLIXR;
@@ -26,10 +26,10 @@ static void GLAPIENTRY MessageCallback([[maybe_unused]] GLenum source, [[maybe_u
         return;
     }
     std::string type_error = (type == GL_DEBUG_TYPE_ERROR) ? "** GL ERROR **" : "";
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
     spdlog::get("illixr")->warn("[shader_util] GL CALLBACK: {} type = {:x}, severity = {:x}, message = {}", type_error, type,
                                 severity, message);
-#endif
+    #endif
     // https://www.khronos.org/opengl/wiki/Debug_Output#Message_Components
     if (severity == GL_DEBUG_SEVERITY_HIGH) {
         /// Fatal error if severity level is high.

--- a/include/illixr/shader_util.hpp
+++ b/include/illixr/shader_util.hpp
@@ -6,9 +6,12 @@
 #include <cstring>
 #include <GL/gl.h>
 #include <GL/glew.h>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 using namespace ILLIXR;
 
@@ -23,8 +26,10 @@ static void GLAPIENTRY MessageCallback([[maybe_unused]] GLenum source, [[maybe_u
         return;
     }
     std::string type_error = (type == GL_DEBUG_TYPE_ERROR) ? "** GL ERROR **" : "";
+#ifdef USE_SPDLOGGER
     spdlog::get("illixr")->warn("[shader_util] GL CALLBACK: {} type = {:x}, severity = {:x}, message = {}", type_error, type,
                                 severity, message);
+#endif
     // https://www.khronos.org/opengl/wiki/Debug_Output#Message_Components
     if (severity == GL_DEBUG_SEVERITY_HIGH) {
         /// Fatal error if severity level is high.

--- a/include/illixr/switchboard.hpp
+++ b/include/illixr/switchboard.hpp
@@ -5,9 +5,9 @@
 #include <mutex>
 #include <shared_mutex>
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
-    #include <spdlog/spdlog.h>
-#endif
+    #ifdef USE_SPDLOGGER
+        #include <spdlog/spdlog.h>
+    #endif
 #endif
 #if __has_include("cpu_timer.hpp")
     #include "cpu_timer.hpp"
@@ -183,11 +183,11 @@ private:
 
         void thread_on_start() {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%^%l%$] [switchboard] thread %t %v");
             spdlog::get("illixr")->debug("start");
             spdlog::get("illixr")->set_pattern("%+");
-#endif
+    #endif
 #endif
         }
 
@@ -294,9 +294,9 @@ private:
     public:
         topic_buffer() {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->info("[switchboard] topic buffer created");
-#endif
+    #endif
 #endif
         }
 
@@ -465,10 +465,10 @@ public:
             : _m_topic{topic_} {
 #ifndef NDEBUG
             if (typeid(specific_event) != _m_topic.ty()) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->error("[switchboard] topic '{}' holds type {}, but caller used type {}", _m_topic.name(),
                                              _m_topic.ty().name(), typeid(specific_event).name());
-#endif
+    #endif
                 abort();
             }
 #endif
@@ -605,10 +605,10 @@ private:
                 topic& topic_ = found->second;
 #ifndef NDEBUG
                 if (typeid(specific_event) != topic_.ty()) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                     spdlog::get("illixr")->error("[switchboard] topic '{}' holds type {}, but caller used type {}", topic_name,
                                                  topic_.ty().name(), typeid(specific_event).name());
-#endif
+    #endif
                     abort();
                 }
 #endif
@@ -617,9 +617,9 @@ private:
         }
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[switchboard] Creating: {} for {}", topic_name, typeid(specific_event).name());
-#endif
+    #endif
 #endif
         // Topic not found. Need to create it here.
         const std::unique_lock lock{_m_registry_lock};

--- a/include/illixr/switchboard.hpp
+++ b/include/illixr/switchboard.hpp
@@ -5,7 +5,9 @@
 #include <mutex>
 #include <shared_mutex>
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
     #include <spdlog/spdlog.h>
+#endif
 #endif
 #if __has_include("cpu_timer.hpp")
     #include "cpu_timer.hpp"
@@ -181,9 +183,11 @@ private:
 
         void thread_on_start() {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%^%l%$] [switchboard] thread %t %v");
             spdlog::get("illixr")->debug("start");
             spdlog::get("illixr")->set_pattern("%+");
+#endif
 #endif
         }
 
@@ -290,7 +294,9 @@ private:
     public:
         topic_buffer() {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->info("[switchboard] topic buffer created");
+#endif
 #endif
         }
 
@@ -459,8 +465,10 @@ public:
             : _m_topic{topic_} {
 #ifndef NDEBUG
             if (typeid(specific_event) != _m_topic.ty()) {
+#ifdef USE_SPDLOGGER
                 spdlog::get("illixr")->error("[switchboard] topic '{}' holds type {}, but caller used type {}", _m_topic.name(),
                                              _m_topic.ty().name(), typeid(specific_event).name());
+#endif
                 abort();
             }
 #endif
@@ -597,8 +605,10 @@ private:
                 topic& topic_ = found->second;
 #ifndef NDEBUG
                 if (typeid(specific_event) != topic_.ty()) {
+#ifdef USE_SPDLOGGER
                     spdlog::get("illixr")->error("[switchboard] topic '{}' holds type {}, but caller used type {}", topic_name,
                                                  topic_.ty().name(), typeid(specific_event).name());
+#endif
                     abort();
                 }
 #endif
@@ -607,7 +617,9 @@ private:
         }
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[switchboard] Creating: {} for {}", topic_name, typeid(specific_event).name());
+#endif
 #endif
         // Topic not found. Need to create it here.
         const std::unique_lock lock{_m_registry_lock};

--- a/include/illixr/vk_util/vulkan_utils.hpp
+++ b/include/illixr/vk_util/vulkan_utils.hpp
@@ -4,9 +4,12 @@
 #include <cstdint>
 #include <fstream>
 #include <iostream>
-#include <spdlog/spdlog.h>
 #include <stdexcept>
 #include <vector>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 #define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
@@ -25,6 +28,7 @@
 #include "third_party/vk_mem_alloc.h"
 #pragma clang diagnostic pop
 
+#ifdef USE_SPDLOGGER
 #define VK_ASSERT_SUCCESS(x)                                                                        \
     {                                                                                               \
         VkResult result = (x);                                                                      \
@@ -33,6 +37,15 @@
             throw std::runtime_error("Vulkan error: " + vulkan_utils::error_string(result));        \
         }                                                                                           \
     }
+#else
+#define VK_ASSERT_SUCCESS(x)                                                                        \
+    {                                                                                               \
+        VkResult result = (x);                                                                      \
+        if (result != VK_SUCCESS) {                                                                 \
+            throw std::runtime_error("Vulkan error: " + vulkan_utils::error_string(result));        \
+        }                                                                                           \
+    }
+#endif
 
 class vulkan_utils {
 public:

--- a/include/illixr/vk_util/vulkan_utils.hpp
+++ b/include/illixr/vk_util/vulkan_utils.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 #define GLM_FORCE_RADIANS
@@ -29,22 +29,22 @@
 #pragma clang diagnostic pop
 
 #ifdef USE_SPDLOGGER
-#define VK_ASSERT_SUCCESS(x)                                                                        \
-    {                                                                                               \
-        VkResult result = (x);                                                                      \
-        if (result != VK_SUCCESS) {                                                                 \
-            spdlog::get("illixr")->debug("[Vulkan] error: {}", vulkan_utils::error_string(result)); \
-            throw std::runtime_error("Vulkan error: " + vulkan_utils::error_string(result));        \
-        }                                                                                           \
-    }
+    #define VK_ASSERT_SUCCESS(x)                                                                        \
+        {                                                                                               \
+            VkResult result = (x);                                                                      \
+            if (result != VK_SUCCESS) {                                                                 \
+                spdlog::get("illixr")->debug("[Vulkan] error: {}", vulkan_utils::error_string(result)); \
+                throw std::runtime_error("Vulkan error: " + vulkan_utils::error_string(result));        \
+            }                                                                                           \
+        }
 #else
-#define VK_ASSERT_SUCCESS(x)                                                                        \
-    {                                                                                               \
-        VkResult result = (x);                                                                      \
-        if (result != VK_SUCCESS) {                                                                 \
-            throw std::runtime_error("Vulkan error: " + vulkan_utils::error_string(result));        \
-        }                                                                                           \
-    }
+    #define VK_ASSERT_SUCCESS(x)                                                                 \
+        {                                                                                        \
+            VkResult result = (x);                                                               \
+            if (result != VK_SUCCESS) {                                                          \
+                throw std::runtime_error("Vulkan error: " + vulkan_utils::error_string(result)); \
+            }                                                                                    \
+        }
 #endif
 
 class vulkan_utils {

--- a/plugins/debugview/CMakeLists.txt
+++ b/plugins/debugview/CMakeLists.txt
@@ -46,7 +46,10 @@ if(BUILD_OPENCV)
 endif()
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${X11_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} ${GLU_INCLUDE_DIR} ${OpenCV_INCLUDE_DIRS} ${glfw3_INCLUDE_DIRS} ${gl_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${glu_LDFLAGS} ${OpenCV_LIBRARIES} glfw OpenGL::GL ${Eigen3_LIBRARIES} dl Threads::Threads spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${glu_LDFLAGS} ${OpenCV_LIBRARIES} glfw OpenGL::GL ${Eigen3_LIBRARIES} dl Threads::Threads)
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/debugview/plugin.cpp
+++ b/plugins/debugview/plugin.cpp
@@ -48,7 +48,9 @@ Eigen::Matrix4f lookAt(const Eigen::Vector3f& eye, const Eigen::Vector3f& target
  * @brief Callback function to handle glfw errors
  */
 static void glfw_error_callback(int error, const char* description) {
+#ifdef USE_SPDLOGGER
     spdlog::get("illixr")->error("|| glfw error_callback: {}\n|> {}", error, description);
+#endif
     ILLIXR::abort();
 }
 
@@ -66,7 +68,9 @@ public:
         , _m_fast_pose{sb->get_reader<imu_raw_type>("imu_raw")} //, glfw_context{pb->lookup_impl<global_config>()->glfw_context}
         , _m_rgb_depth(sb->get_reader<rgb_depth_type>("rgb_depth"))
         , _m_cam{sb->get_buffered_reader<cam_type>("cam")} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("DEBUGVIEW_LOG_LEVEL"));
+#endif
     }
 
     void draw_GUI() {
@@ -494,7 +498,9 @@ public:
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
         gui_window = glfwCreateWindow(1600, 1000, "ILLIXR Debug View", nullptr, nullptr);
         if (gui_window == nullptr) {
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->error("couldn't create window {}:{}", __FILE__, __LINE__);
+#endif
             ILLIXR::abort();
         }
 
@@ -512,7 +518,9 @@ public:
         // Init and verify GLEW
         const GLenum glew_err = glewInit();
         if (glew_err != GLEW_OK) {
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->error("GLEW Error: {}", glewGetErrorString(glew_err));
+#endif
             glfwDestroyWindow(gui_window);
             ILLIXR::abort("[debugview] Failed to initialize GLEW");
         }
@@ -535,7 +543,9 @@ public:
 
         demoShaderProgram = init_and_link(demo_vertex_shader, demo_fragment_shader);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Demo app shader program is program {}", demoShaderProgram);
+#endif
 #endif
 
         vertexPosAttr    = glGetAttribLocation(demoShaderProgram, "vertexPosition");

--- a/plugins/debugview/plugin.cpp
+++ b/plugins/debugview/plugin.cpp
@@ -543,9 +543,9 @@ public:
 
         demoShaderProgram = init_and_link(demo_vertex_shader, demo_fragment_shader);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Demo app shader program is program {}", demoShaderProgram);
-#endif
+    #endif
 #endif
 
         vertexPosAttr    = glGetAttribLocation(demoShaderProgram, "vertexPosition");

--- a/plugins/depthai/CMakeLists.txt
+++ b/plugins/depthai/CMakeLists.txt
@@ -24,7 +24,10 @@ target_include_directories(${PLUGIN_NAME} PRIVATE ${DepthAI_INCLUDE_DIRS} ${Open
 # if we are building DepthAI from source
 if(DepthAI_EXTERNAL)
     add_dependencies(${PLUGIN_NAME} DepthAI_ext)
-    target_link_libraries(${PLUGIN_NAME} PUBLIC ${DEPENDENCIES} ${OpenCV_LIBRARIES} PRIVATE ${DepthAI_LIBRARIES} spdlog::spdlog)
+    target_link_libraries(${PLUGIN_NAME} PUBLIC ${DEPENDENCIES} ${OpenCV_LIBRARIES} PRIVATE ${DepthAI_LIBRARIES})
+if(USE_SPDLOGGER)
+    target_link_libraries(${PLUGIN_NAME} PRIVATE spdlog::spdlog)
+endif()
 else()  # DepthAI already installed
     target_link_libraries(${PLUGIN_NAME} PUBLIC ${DEPENDENCIES} ${OpenCV_LIBRARIES} PRIVATE depthai::core)
 endif()

--- a/plugins/depthai/plugin.cpp
+++ b/plugins/depthai/plugin.cpp
@@ -30,9 +30,13 @@ public:
         , _m_cam{sb->get_writer<cam_type>("cam")}
         , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")} // Initialize DepthAI pipeline and device
         , device{createCameraPipeline()} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("DEPTHAI_LOG_LEVEL"));
+#endif
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("pipeline started");
+#endif
 #endif
         colorQueue                             = device.getOutputQueue("preview", 1, false);
         depthQueue                             = device.getOutputQueue("depth", 1, false);
@@ -157,12 +161,16 @@ public:
 
     ~depthai() override {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Destructor: Packets Received {} Published: IMU: {} RGB-D: {}", imu_packet, imu_pub, rgbd_pub);
+#endif
         auto dur = std::chrono::steady_clock::now() - first_packet_time;
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Time since first packet: {} ms",
                                  std::chrono::duration_cast<std::chrono::milliseconds>(dur).count());
         spdlog::get(name)->debug("RGB: {} Left: {} Right: {} Depth: {} All: {}", rgb_count, left_count, right_count,
                                  depth_count, all_count);
+#endif
 #endif
     }
 
@@ -203,7 +211,9 @@ private:
 
     dai::Pipeline createCameraPipeline() const {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("creating pipeline");
+#endif
 #endif
         dai::Pipeline p;
 

--- a/plugins/depthai/plugin.cpp
+++ b/plugins/depthai/plugin.cpp
@@ -34,9 +34,9 @@ public:
         spdlogger(std::getenv("DEPTHAI_LOG_LEVEL"));
 #endif
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("pipeline started");
-#endif
+    #endif
 #endif
         colorQueue                             = device.getOutputQueue("preview", 1, false);
         depthQueue                             = device.getOutputQueue("depth", 1, false);
@@ -161,16 +161,16 @@ public:
 
     ~depthai() override {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Destructor: Packets Received {} Published: IMU: {} RGB-D: {}", imu_packet, imu_pub, rgbd_pub);
-#endif
+    #endif
         auto dur = std::chrono::steady_clock::now() - first_packet_time;
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Time since first packet: {} ms",
                                  std::chrono::duration_cast<std::chrono::milliseconds>(dur).count());
         spdlog::get(name)->debug("RGB: {} Left: {} Right: {} Depth: {} All: {}", rgb_count, left_count, right_count,
                                  depth_count, all_count);
-#endif
+    #endif
 #endif
     }
 
@@ -211,9 +211,9 @@ private:
 
     dai::Pipeline createCameraPipeline() const {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("creating pipeline");
-#endif
+    #endif
 #endif
         dai::Pipeline p;
 

--- a/plugins/display_vk/CMakeLists.txt
+++ b/plugins/display_vk/CMakeLists.txt
@@ -52,7 +52,10 @@ add_dependencies(${PLUGIN_NAME} Display_VK_Shaders)
 set_target_properties(${PLUGIN_NAME} PROPERTIES OUTPUT_NAME ${PLUGIN_NAME})
 
 target_link_libraries(${PLUGIN_NAME} glfw)
-target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_include_directories(${PLUGIN_NAME} PUBLIC ${Vulkan_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include)
 
 add_custom_command(TARGET ${PLUGIN_NAME} POST_BUILD

--- a/plugins/display_vk/plugin.cpp
+++ b/plugins/display_vk/plugin.cpp
@@ -88,7 +88,9 @@ private:
                                        const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData) -> VkBool32 {
                     auto severity = vkb::to_string_message_severity(messageSeverity);
                     auto type     = vkb::to_string_message_type(messageType);
+#ifdef USE_SPDLOGGER
                     spdlog::get("illixr")->debug("[display_vk] [{}: {}] {}", severity, type, pCallbackData->pMessage);
+#endif
                     return VK_FALSE;
                 })
                 .build();
@@ -163,8 +165,10 @@ private:
         swapchain_extent       = vkb_swapchain.extent;
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[display_vk] present_mode: {}", vkb_swapchain.present_mode);
         spdlog::get("illixr")->debug("[display_vk] swapchain_extent: {} {}", swapchain_extent.width, swapchain_extent.height);
+#endif
 #endif
         vma_allocator = vulkan_utils::create_vma_allocator(vk_instance, vk_physical_device, vk_device);
     }

--- a/plugins/display_vk/plugin.cpp
+++ b/plugins/display_vk/plugin.cpp
@@ -165,10 +165,10 @@ private:
         swapchain_extent       = vkb_swapchain.extent;
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[display_vk] present_mode: {}", vkb_swapchain.present_mode);
         spdlog::get("illixr")->debug("[display_vk] swapchain_extent: {} {}", swapchain_extent.width, swapchain_extent.height);
-#endif
+    #endif
 #endif
         vma_allocator = vulkan_utils::create_vma_allocator(vk_instance, vk_physical_device, vk_device);
     }

--- a/plugins/fauxpose/CMakeLists.txt
+++ b/plugins/fauxpose/CMakeLists.txt
@@ -10,7 +10,9 @@ set(FAUXPOSE_SOURCES plugin.cpp
 add_library(${PLUGIN_NAME} SHARED ${FAUXPOSE_SOURCES})
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${ILLIXR_SOURCE_DIR}/include)
+if(USE_SPDLOGGER)
 target_link_libraries(${PLUGIN_NAME} PUBLIC spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/fauxpose/plugin.cpp
+++ b/plugins/fauxpose/plugin.cpp
@@ -54,18 +54,24 @@ public:
         , _m_vsync_estimate{sb->get_reader<switchboard::event_wrapper<time_point>>("vsync_estimate")} {
         char* env_input; /* pointer to environment variable input */
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Starting Service");
+#endif
 #endif
 
         // Store the initial time
         if (_m_clock->is_started()) {
             sim_start_time = _m_clock->now();
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[fauxpose] Starting Service");
+#endif
 #endif
         } else {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[fauxpose] Warning: the clock isn't started yet");
+#endif
 #endif
         }
 
@@ -87,17 +93,21 @@ public:
             center_location[2] = std::strtof(strchrnul(strchrnul(env_input, ',') + 1, ',') + 1, nullptr);
         }
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Period is {}", period);
         spdlog::get("illixr")->debug("[fauxpose] Amplitude is {}", amplitude);
         spdlog::get("illixr")->debug("[fauxpose] Center is {}, {}, {}", center_location[0], center_location[1],
                                      center_location[2]);
+#endif
 #endif
     }
 
     // ********************************************************************
     ~faux_pose_impl() override {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Ending Service");
+#endif
 #endif
     }
 
@@ -119,6 +129,7 @@ public:
     // ********************************************************************
     pose_type correct_pose([[maybe_unused]] const pose_type& pose) const override {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Returning (passthru) pose");
 #endif
         return pose;
@@ -174,7 +185,9 @@ public:
 
         // Return the new pose
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Returning pose");
+#endif
 #endif
         return fast_pose_type{.pose = simulated_pose, .predict_computed_time = _m_clock->now(), .predict_target_time = time};
     }
@@ -209,14 +222,18 @@ public:
         //   It is described in "pose_prediction.hpp"
         pb->register_impl<pose_prediction>(std::static_pointer_cast<pose_prediction>(std::make_shared<faux_pose_impl>(pb)));
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Starting Plugin");
+#endif
 #endif
     }
 
     // ********************************************************************
     ~faux_pose() override {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Ending Plugin");
+#endif
 #endif
     }
 };

--- a/plugins/fauxpose/plugin.cpp
+++ b/plugins/fauxpose/plugin.cpp
@@ -54,24 +54,24 @@ public:
         , _m_vsync_estimate{sb->get_reader<switchboard::event_wrapper<time_point>>("vsync_estimate")} {
         char* env_input; /* pointer to environment variable input */
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Starting Service");
-#endif
+    #endif
 #endif
 
         // Store the initial time
         if (_m_clock->is_started()) {
             sim_start_time = _m_clock->now();
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[fauxpose] Starting Service");
-#endif
+    #endif
 #endif
         } else {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[fauxpose] Warning: the clock isn't started yet");
-#endif
+    #endif
 #endif
         }
 
@@ -93,21 +93,21 @@ public:
             center_location[2] = std::strtof(strchrnul(strchrnul(env_input, ',') + 1, ',') + 1, nullptr);
         }
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Period is {}", period);
         spdlog::get("illixr")->debug("[fauxpose] Amplitude is {}", amplitude);
         spdlog::get("illixr")->debug("[fauxpose] Center is {}, {}, {}", center_location[0], center_location[1],
                                      center_location[2]);
-#endif
+    #endif
 #endif
     }
 
     // ********************************************************************
     ~faux_pose_impl() override {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Ending Service");
-#endif
+    #endif
 #endif
     }
 
@@ -129,9 +129,9 @@ public:
     // ********************************************************************
     pose_type correct_pose([[maybe_unused]] const pose_type& pose) const override {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Returning (passthru) pose");
-#endif
+    #endif
         return pose;
     }
 
@@ -184,11 +184,11 @@ public:
         simulated_pose.orientation = Eigen::Quaternionf(0.707, 0.0, 0.707, 0.0); // (W,X,Y,Z) Facing forward (90deg about Y)
 
         // Return the new pose
-#ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifndef NDEBUG
+        #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Returning pose");
-#endif
-#endif
+        #endif
+    #endif
         return fast_pose_type{.pose = simulated_pose, .predict_computed_time = _m_clock->now(), .predict_target_time = time};
     }
 
@@ -221,20 +221,20 @@ public:
         // "pose_prediction" is a class inheriting from "phonebook::service"
         //   It is described in "pose_prediction.hpp"
         pb->register_impl<pose_prediction>(std::static_pointer_cast<pose_prediction>(std::make_shared<faux_pose_impl>(pb)));
-#ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifndef NDEBUG
+        #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Starting Plugin");
-#endif
-#endif
+        #endif
+    #endif
     }
 
     // ********************************************************************
     ~faux_pose() override {
-#ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifndef NDEBUG
+        #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[fauxpose] Ending Plugin");
-#endif
-#endif
+        #endif
+    #endif
     }
 };
 

--- a/plugins/gldemo/CMakeLists.txt
+++ b/plugins/gldemo/CMakeLists.txt
@@ -18,7 +18,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
         )
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${X11_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} ${GLU_INCLUDE_DIR} ${gl_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${glu_LDFLAGS} ${gl_LIBRARIES}  ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${glu_LDFLAGS} ${gl_LIBRARIES}  ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/gldemo/plugin.cpp
+++ b/plugins/gldemo/plugin.cpp
@@ -44,7 +44,9 @@ public:
         , _m_vsync{sb->get_reader<switchboard::event_wrapper<time_point>>("vsync_estimate")}
         , _m_image_handle{sb->get_writer<image_handle>("image_handle")}
         , _m_eyebuffer{sb->get_writer<rendered_frame>("eyebuffer")} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("GLDEMO_LOG_LEVEL"));
+#endif
     }
 
     // Essentially, a crude equivalent of XRWaitFrame.
@@ -63,7 +65,9 @@ public:
 #ifndef NDEBUG
         if (log_count > LOG_PERIOD) {
             double vsync_in = duration2double<std::milli>(**next_vsync - now);
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("First vsync is in {} ms", vsync_in);
+#endif
         }
 #endif
 
@@ -84,7 +88,9 @@ public:
 #ifndef NDEBUG
             if (log_count > LOG_PERIOD) {
                 double wait_in = duration2double<std::milli>(wait_time - now);
+#ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Waiting until next vsync, in {} ms", wait_in);
+#endif
             }
 #endif
             // Perform the sleep.
@@ -93,9 +99,11 @@ public:
             std::this_thread::sleep_for(wait_time - now);
         } else {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             if (log_count > LOG_PERIOD) {
                 spdlog::get(name)->debug("We haven't rendered yet, rendering immediately");
             }
+#endif
 #endif
         }
     }
@@ -177,10 +185,12 @@ public:
         const double frame_duration_s = duration2double(_m_clock->now() - lastTime);
         const double fps              = 1.0 / frame_duration_s;
 
+#ifdef USE_SPDLOGGER
         if (log_count > LOG_PERIOD) {
             spdlog::get(name)->debug("Submitting frame to buffer {}, frametime: {}, FPS: {}", which_buffer, frame_duration_s,
                                      fps);
         }
+#endif
 #endif
         lastTime = _m_clock->now();
 
@@ -277,7 +287,9 @@ private:
         glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
         // Bind eyebuffer texture
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->info("About to bind eyebuffer texture, texture handle: {}", *texture_handle);
+#endif
 
         glBindTexture(GL_TEXTURE_2D, *texture_handle);
         glFramebufferTexture(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, *texture_handle, 0);
@@ -299,7 +311,9 @@ public:
         // Init and verify GLEW
         const GLenum glew_err = glewInit();
         if (glew_err != GLEW_OK) {
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->error("GLEW Error: {}", glewGetErrorString(glew_err));
+#endif
             ILLIXR::abort("Failed to initialize GLEW");
         }
 
@@ -323,7 +337,9 @@ public:
 
         demoShaderProgram = init_and_link(demo_vertex_shader, demo_fragment_shader);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Demo app shader program is program {}", demoShaderProgram);
+#endif
 #endif
 
         vertexPosAttr    = glGetAttribLocation(demoShaderProgram, "vertexPosition");

--- a/plugins/gldemo/plugin.cpp
+++ b/plugins/gldemo/plugin.cpp
@@ -65,9 +65,9 @@ public:
 #ifndef NDEBUG
         if (log_count > LOG_PERIOD) {
             double vsync_in = duration2double<std::milli>(**next_vsync - now);
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("First vsync is in {} ms", vsync_in);
-#endif
+    #endif
         }
 #endif
 
@@ -88,9 +88,9 @@ public:
 #ifndef NDEBUG
             if (log_count > LOG_PERIOD) {
                 double wait_in = duration2double<std::milli>(wait_time - now);
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Waiting until next vsync, in {} ms", wait_in);
-#endif
+    #endif
             }
 #endif
             // Perform the sleep.
@@ -99,11 +99,11 @@ public:
             std::this_thread::sleep_for(wait_time - now);
         } else {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             if (log_count > LOG_PERIOD) {
                 spdlog::get(name)->debug("We haven't rendered yet, rendering immediately");
             }
-#endif
+    #endif
 #endif
         }
     }
@@ -185,12 +185,12 @@ public:
         const double frame_duration_s = duration2double(_m_clock->now() - lastTime);
         const double fps              = 1.0 / frame_duration_s;
 
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         if (log_count > LOG_PERIOD) {
             spdlog::get(name)->debug("Submitting frame to buffer {}, frametime: {}, FPS: {}", which_buffer, frame_duration_s,
                                      fps);
         }
-#endif
+    #endif
 #endif
         lastTime = _m_clock->now();
 
@@ -337,9 +337,9 @@ public:
 
         demoShaderProgram = init_and_link(demo_vertex_shader, demo_fragment_shader);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Demo app shader program is program {}", demoShaderProgram);
-#endif
+    #endif
 #endif
 
         vertexPosAttr    = glGetAttribLocation(demoShaderProgram, "vertexPosition");

--- a/plugins/ground_truth_slam/CMakeLists.txt
+++ b/plugins/ground_truth_slam/CMakeLists.txt
@@ -14,7 +14,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
 
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 target_include_directories(${PLUGIN_NAME} PRIVATE ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)
 

--- a/plugins/ground_truth_slam/data_loading.hpp
+++ b/plugins/ground_truth_slam/data_loading.hpp
@@ -8,8 +8,11 @@
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <spdlog/spdlog.h>
 #include <string>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 // timestamp
 // p_RS_R_x [m], p_RS_R_y [m], p_RS_R_z [m]
@@ -35,7 +38,9 @@ static std::map<ullong, sensor_types> load_data() {
     std::ifstream gt_file{illixr_data + subpath};
 
     if (!gt_file.good()) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[groundtruthslam] ${ILLIXR_DATA} {0} ({1}{0}) is not a good path", subpath, illixr_data);
+#endif
         ILLIXR::abort();
     }
 

--- a/plugins/ground_truth_slam/data_loading.hpp
+++ b/plugins/ground_truth_slam/data_loading.hpp
@@ -11,7 +11,7 @@
 #include <string>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 // timestamp

--- a/plugins/ground_truth_slam/plugin.cpp
+++ b/plugins/ground_truth_slam/plugin.cpp
@@ -46,9 +46,9 @@ public:
         auto   it           = _m_sensor_data.find(rounded_time);
         if (it == _m_sensor_data.end()) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("True pose not found at timestamp: {}", rounded_time);
-#endif
+    #endif
 #endif
             return;
         }
@@ -57,12 +57,12 @@ public:
             _m_true_pose.allocate<pose_type>(pose_type{time_point{datum->time}, it->second.position, it->second.orientation});
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Ground truth pose was found at T: {} | Pos: ({}, {}, {}) | Quat: ({}, {}, {}, {})",
                                  rounded_time, true_pose->position[0], true_pose->position[1], true_pose->position[2],
                                  true_pose->orientation.w(), true_pose->orientation.x(), true_pose->orientation.y(),
                                  true_pose->orientation.z());
-#endif
+    #endif
 #endif
 
         /// Ground truth position offset is the first ground truth position

--- a/plugins/ground_truth_slam/plugin.cpp
+++ b/plugins/ground_truth_slam/plugin.cpp
@@ -29,7 +29,9 @@ public:
         // TODO: Change the hardcoded number to be read from some configuration variables in the yaml file.
         , _m_dataset_first_time{ViconRoom1Medium}
         , _m_first_time{true} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("GROUND_TRUTH_SLAM_LOG_LEVEL"));
+#endif
     }
 
     void start() override {
@@ -44,7 +46,9 @@ public:
         auto   it           = _m_sensor_data.find(rounded_time);
         if (it == _m_sensor_data.end()) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("True pose not found at timestamp: {}", rounded_time);
+#endif
 #endif
             return;
         }
@@ -53,10 +57,12 @@ public:
             _m_true_pose.allocate<pose_type>(pose_type{time_point{datum->time}, it->second.position, it->second.orientation});
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Ground truth pose was found at T: {} | Pos: ({}, {}, {}) | Quat: ({}, {}, {}, {})",
                                  rounded_time, true_pose->position[0], true_pose->position[1], true_pose->position[2],
                                  true_pose->orientation.w(), true_pose->orientation.x(), true_pose->orientation.y(),
                                  true_pose->orientation.z());
+#endif
 #endif
 
         /// Ground truth position offset is the first ground truth position

--- a/plugins/gtsam_integrator/CMakeLists.txt
+++ b/plugins/gtsam_integrator/CMakeLists.txt
@@ -16,7 +16,10 @@ endif()
 
 #add_definitions(-Wall -Wextra -Werror)
 target_include_directories(${PLUGIN_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${GTSAM_INCLUDE_DIR} ${EIGEN3_INCLUDE_DIR} ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${GTSAM_LIBRARIES} ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${GTSAM_LIBRARIES} ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)
 

--- a/plugins/gtsam_integrator/plugin.cpp
+++ b/plugins/gtsam_integrator/plugin.cpp
@@ -29,7 +29,9 @@ public:
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , _m_imu_integrator_input{sb->get_reader<imu_integrator_input>("imu_integrator_input")}
         , _m_imu_raw{sb->get_writer<imu_raw_type>("imu_raw")} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("GTSAM_INTEGRATOR_LOG_LEVEL"));
+#endif
         sb->schedule<imu_type>(id, "imu", [&](const switchboard::ptr<const imu_type>& datum, size_t) {
             callback(datum);
         });
@@ -175,7 +177,9 @@ private:
 
 #ifndef NDEBUG
         if (input_values->last_cam_integration_time > last_cam_time) {
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("New slow pose has arrived!");
+#endif
             last_cam_time = input_values->last_cam_integration_time;
         }
 #endif
@@ -211,7 +215,9 @@ private:
         ImuBias bias      = _pim_obj->biasHat();
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Integrating over {} IMU samples", prop_data.size());
+#endif
 #endif
 
         for (std::size_t i = 0; i < prop_data.size() - 1; i++) {
@@ -225,9 +231,11 @@ private:
         gtsam::Pose3    out_pose   = navstate_k.pose();
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Base Position (x, y, z) = {}, {}, {}", input_values->position(0), input_values->position(1),
                                  input_values->position(2));
         spdlog::get(name)->debug("New Position (x, y, z) = {}, {}, {}", out_pose.x(), out_pose.y(), out_pose.z());
+#endif
 #endif
 
         auto                        seconds_since_epoch = std::chrono::duration<double>(real_time.time_since_epoch()).count();

--- a/plugins/gtsam_integrator/plugin.cpp
+++ b/plugins/gtsam_integrator/plugin.cpp
@@ -177,9 +177,9 @@ private:
 
 #ifndef NDEBUG
         if (input_values->last_cam_integration_time > last_cam_time) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("New slow pose has arrived!");
-#endif
+    #endif
             last_cam_time = input_values->last_cam_integration_time;
         }
 #endif
@@ -215,9 +215,9 @@ private:
         ImuBias bias      = _pim_obj->biasHat();
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Integrating over {} IMU samples", prop_data.size());
-#endif
+    #endif
 #endif
 
         for (std::size_t i = 0; i < prop_data.size() - 1; i++) {
@@ -231,11 +231,11 @@ private:
         gtsam::Pose3    out_pose   = navstate_k.pose();
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Base Position (x, y, z) = {}, {}, {}", input_values->position(0), input_values->position(1),
                                  input_values->position(2));
         spdlog::get(name)->debug("New Position (x, y, z) = {}, {}, {}", out_pose.x(), out_pose.y(), out_pose.z());
-#endif
+    #endif
 #endif
 
         auto                        seconds_since_epoch = std::chrono::duration<double>(real_time.time_since_epoch()).count();

--- a/plugins/native_renderer/CMakeLists.txt
+++ b/plugins/native_renderer/CMakeLists.txt
@@ -21,7 +21,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
 
 set_target_properties(${PLUGIN_NAME} PROPERTIES OUTPUT_NAME ${PLUGIN_NAME})
 
-target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_include_directories(${PLUGIN_NAME} PUBLIC ${Vulkan_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/native_renderer/plugin.cpp
+++ b/plugins/native_renderer/plugin.cpp
@@ -32,7 +32,9 @@ public:
         , src{pb->lookup_impl<app>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , last_fps_update{std::chrono::duration<long, std::nano>{0}} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("NATIVE_RENDERER_LOG_LEVEL"));
+#endif
     }
 
     /**

--- a/plugins/offline_cam/CMakeLists.txt
+++ b/plugins/offline_cam/CMakeLists.txt
@@ -21,7 +21,10 @@ if(BUILD_OPENCV)
 endif()
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${OpenCV_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${OpenCV_LIBRARIES} ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${OpenCV_LIBRARIES} ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/offline_cam/data_loading.hpp
+++ b/plugins/offline_cam/data_loading.hpp
@@ -12,7 +12,7 @@
 #include <utility>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 typedef unsigned long long ullong;

--- a/plugins/offline_cam/data_loading.hpp
+++ b/plugins/offline_cam/data_loading.hpp
@@ -8,9 +8,12 @@
 #include <map>
 #include <opencv2/core/mat.hpp>
 #include <opencv2/imgcodecs.hpp>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <utility>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 typedef unsigned long long ullong;
 
@@ -55,7 +58,9 @@ typedef struct {
 static std::map<ullong, sensor_types> load_data() {
     const char* illixr_data_c_str = std::getenv("ILLIXR_DATA");
     if (!illixr_data_c_str) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[offline_cam] Please define ILLIXR_DATA");
+#endif
         ILLIXR::abort();
     }
     std::string illixr_data = std::string{illixr_data_c_str};
@@ -65,7 +70,9 @@ static std::map<ullong, sensor_types> load_data() {
     const std::string cam0_subpath = "/cam0/data.csv";
     std::ifstream     cam0_file{illixr_data + cam0_subpath};
     if (!cam0_file.good()) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[offline_cam] ${ILLIXR_DATA} {0} ({1}{0}) is not a good path", cam0_subpath, illixr_data);
+#endif
         ILLIXR::abort();
     }
     for (CSVIterator row{cam0_file, 1}; row != CSVIterator{}; ++row) {
@@ -76,7 +83,9 @@ static std::map<ullong, sensor_types> load_data() {
     const std::string cam1_subpath = "/cam1/data.csv";
     std::ifstream     cam1_file{illixr_data + cam1_subpath};
     if (!cam1_file.good()) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[offline_cam] ${ILLIXR_DATA} {0} ({1}{0}) is not a good path", cam1_subpath, illixr_data);
+#endif
         ILLIXR::abort();
     }
     for (CSVIterator row{cam1_file, 1}; row != CSVIterator{}; ++row) {

--- a/plugins/offline_cam/plugin.cpp
+++ b/plugins/offline_cam/plugin.cpp
@@ -21,7 +21,9 @@ public:
         , last_ts{0}
         , _m_rtc{pb->lookup_impl<RelativeClock>()}
         , next_row{_m_sensor_data.cbegin()} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("OFFLINE_CAM_LOG_LEVEL"));
+#endif
     }
 
     skip_option _p_should_skip() override {
@@ -43,9 +45,11 @@ public:
 
         if (after_nearest_row == _m_sensor_data.cend()) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->warn("Running out of the dataset! Time {} ({} + {}) after last datum {}", lookup_time,
                                     _m_rtc->now().time_since_epoch().count(), dataset_first_time,
                                     _m_sensor_data.rbegin()->first);
+#endif
 #endif
             // Handling the last camera images. There's no more rows after the nearest_row, so we set after_nearest_row
             // to be nearest_row to avoiding sleeping at the end.
@@ -56,9 +60,11 @@ public:
         } else if (after_nearest_row == _m_sensor_data.cbegin()) {
             // Should not happen because lookup_time is bigger than dataset_first_time
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->warn("Time {} ({} + {}) before first datum {}", lookup_time,
                                     _m_rtc->now().time_since_epoch().count(), dataset_first_time,
                                     _m_sensor_data.cbegin()->first);
+#endif
 #endif
         } else {
             // Most recent

--- a/plugins/offline_cam/plugin.cpp
+++ b/plugins/offline_cam/plugin.cpp
@@ -45,11 +45,11 @@ public:
 
         if (after_nearest_row == _m_sensor_data.cend()) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->warn("Running out of the dataset! Time {} ({} + {}) after last datum {}", lookup_time,
                                     _m_rtc->now().time_since_epoch().count(), dataset_first_time,
                                     _m_sensor_data.rbegin()->first);
-#endif
+    #endif
 #endif
             // Handling the last camera images. There's no more rows after the nearest_row, so we set after_nearest_row
             // to be nearest_row to avoiding sleeping at the end.
@@ -60,11 +60,11 @@ public:
         } else if (after_nearest_row == _m_sensor_data.cbegin()) {
             // Should not happen because lookup_time is bigger than dataset_first_time
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->warn("Time {} ({} + {}) before first datum {}", lookup_time,
                                     _m_rtc->now().time_since_epoch().count(), dataset_first_time,
                                     _m_sensor_data.cbegin()->first);
-#endif
+    #endif
 #endif
         } else {
             // Most recent

--- a/plugins/offline_imu/CMakeLists.txt
+++ b/plugins/offline_imu/CMakeLists.txt
@@ -16,6 +16,9 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
 
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 target_include_directories(${PLUGIN_NAME} PRIVATE ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${Eigne3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Eigne3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/offline_imu/data_loading.hpp
+++ b/plugins/offline_imu/data_loading.hpp
@@ -6,8 +6,11 @@
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <spdlog/spdlog.h>
 #include <string>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 typedef unsigned long long ullong;
 
@@ -23,7 +26,9 @@ typedef struct {
 static std::map<ullong, sensor_types> load_data() {
     const char* illixr_data_c_str = std::getenv("ILLIXR_DATA");
     if (!illixr_data_c_str) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[offline_imu] Please define ILLIXR_DATA");
+#endif
         ILLIXR::abort();
     }
     std::string illixr_data = std::string{illixr_data_c_str};
@@ -33,7 +38,9 @@ static std::map<ullong, sensor_types> load_data() {
     const std::string imu0_subpath = "/imu0/data.csv";
     std::ifstream     imu0_file{illixr_data + imu0_subpath};
     if (!imu0_file.good()) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[offline_imu] ${ILLIXR_DATA} {0} ({1}{0}) is not a good path", imu0_subpath, illixr_data);
+#endif
         ILLIXR::abort();
     }
     for (CSVIterator row{imu0_file, 1}; row != CSVIterator{}; ++row) {

--- a/plugins/offline_imu/data_loading.hpp
+++ b/plugins/offline_imu/data_loading.hpp
@@ -9,7 +9,7 @@
 #include <string>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 typedef unsigned long long ullong;

--- a/plugins/offload_data/CMakeLists.txt
+++ b/plugins/offload_data/CMakeLists.txt
@@ -13,7 +13,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
         )
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${Boost_INCLUDE_DIR} ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} boost_filesystem ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} boost_filesystem ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/offload_data/plugin.cpp
+++ b/plugins/offload_data/plugin.cpp
@@ -28,7 +28,9 @@ public:
         , enable_offload{ILLIXR::str_to_bool(ILLIXR::getenv_or("ILLIXR_OFFLOAD_ENABLE", "False"))}
         , is_success{true} /// TODO: Set with #198
         , obj_dir{ILLIXR::getenv_or("ILLIXR_OFFLOAD_PATH", "metrics/offloaded_data/")} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("OFFLOAD_DATA_LOG_LEVEL"));
+#endif
         sb->schedule<texture_pose>(id, "texture_pose", [&](const switchboard::ptr<const texture_pose>& datum, size_t) {
             callback(datum);
         });
@@ -36,7 +38,9 @@ public:
 
     void callback(const switchboard::ptr<const texture_pose>& datum) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Image index: {}", img_idx++);
+#endif
 #endif
         /// A texture pose is present. Store it back to our container.
         _offload_data_container.push_back(datum);
@@ -101,7 +105,9 @@ private:
     void writeDataToDisk() {
         stbi_flip_vertically_on_write(true);
 
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->info("Writing offloaded images to disk...");
+#endif
         img_idx = 0;
         for (auto& container_it : _offload_data_container) {
             // Get collecting time for each frame

--- a/plugins/offload_data/plugin.cpp
+++ b/plugins/offload_data/plugin.cpp
@@ -38,9 +38,9 @@ public:
 
     void callback(const switchboard::ptr<const texture_pose>& datum) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Image index: {}", img_idx++);
-#endif
+    #endif
 #endif
         /// A texture pose is present. Store it back to our container.
         _offload_data_container.push_back(datum);

--- a/plugins/offload_vio/device_rx/CMakeLists.txt
+++ b/plugins/offload_vio/device_rx/CMakeLists.txt
@@ -21,10 +21,10 @@ set(protobuf_files
 target_include_directories(${PLUGIN_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${Protobuf_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include)
 
 PROTOBUF_TARGET_CPP(${PLUGIN_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../proto ${protobuf_files})
-target_link_libraries(${PLUGIN_NAME}
-        protobuf::libprotobuf
-        spdlog::spdlog
-        )
+target_link_libraries(${PLUGIN_NAME} protobuf::libprotobuf)
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 

--- a/plugins/offload_vio/device_rx/plugin.cpp
+++ b/plugins/offload_vio/device_rx/plugin.cpp
@@ -20,7 +20,9 @@ public:
         , _m_imu_integrator_input{sb->get_writer<imu_integrator_input>("imu_integrator_input")}
         , server_ip(SERVER_IP)
         , server_port(SERVER_PORT_2) {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+#endif
         pose_type                   datum_pose_tmp{time_point{}, Eigen::Vector3f{0, 0, 0}, Eigen::Quaternionf{1, 0, 0, 0}};
         switchboard::ptr<pose_type> datum_pose = _m_pose.allocate<pose_type>(std::move(datum_pose_tmp));
         _m_pose.put(std::move(datum_pose));
@@ -34,11 +36,15 @@ public:
     skip_option _p_should_skip() override {
         if (!is_socket_connected) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.device_rx]: Connecting to {}:{}", server_ip, server_port);
+#endif
 #endif
             socket.socket_connect(server_ip, server_port);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.device_rx]: Connected to {}:{}", server_ip, server_port);
+#endif
 #endif
             is_socket_connected = true;
         }
@@ -62,7 +68,9 @@ public:
                     if (success) {
                         ReceiveVioOutput(vio_output, before);
                     } else {
+#ifdef USE_SPDLOGGER
                         spdlog::get(name)->error("[offload_vio.device_rx: Cannot parse VIO output!!");
+#endif
                     }
                     end_position = buffer_str.find(delimitter);
                 }

--- a/plugins/offload_vio/device_rx/plugin.cpp
+++ b/plugins/offload_vio/device_rx/plugin.cpp
@@ -36,15 +36,15 @@ public:
     skip_option _p_should_skip() override {
         if (!is_socket_connected) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.device_rx]: Connecting to {}:{}", server_ip, server_port);
-#endif
+    #endif
 #endif
             socket.socket_connect(server_ip, server_port);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.device_rx]: Connected to {}:{}", server_ip, server_port);
-#endif
+    #endif
 #endif
             is_socket_connected = true;
         }

--- a/plugins/offload_vio/device_tx/CMakeLists.txt
+++ b/plugins/offload_vio/device_tx/CMakeLists.txt
@@ -46,7 +46,7 @@ include_directories(
         ${GLIB_INCLUDE_DIRS}
 )
 
-target_link_libraries(${PLUGIN_NAME} ${GST_APP_LIBRARIES} ${GST_VIDEO_LIBRARIES} ${GST_AUDIO_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${GST_APP_LIBRARIES} ${GST_VIDEO_LIBRARIES} ${GST_AUDIO_LIBRARIES})
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/offload_vio/device_tx/plugin.cpp
+++ b/plugins/offload_vio/device_tx/plugin.cpp
@@ -67,15 +67,15 @@ public:
         encoder->init();
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.device_tx] TEST: Connecting to {}:{}", server_ip, server_port);
-#endif
+    #endif
 #endif
         socket.socket_connect(server_ip, server_port);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.device_tx] Connected to {}:{}", server_ip, server_port);
-#endif
+    #endif
 #endif
 
         sb->schedule<imu_type>(id, "imu", [this](const switchboard::ptr<const imu_type>& datum, std::size_t) {

--- a/plugins/offload_vio/device_tx/plugin.cpp
+++ b/plugins/offload_vio/device_tx/plugin.cpp
@@ -37,7 +37,9 @@ public:
         , _m_cam{sb->get_buffered_reader<cam_type>("cam")}
         , server_ip(SERVER_IP)
         , server_port(SERVER_PORT_1) {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+#endif
         socket.socket_set_reuseaddr();
         socket.socket_bind(CLIENT_IP, CLIENT_PORT_1);
         socket.enable_no_delay();
@@ -65,11 +67,15 @@ public:
         encoder->init();
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.device_tx] TEST: Connecting to {}:{}", server_ip, server_port);
+#endif
 #endif
         socket.socket_connect(server_ip, server_port);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.device_tx] Connected to {}:{}", server_ip, server_port);
+#endif
 #endif
 
         sb->schedule<imu_type>(id, "imu", [this](const switchboard::ptr<const imu_type>& datum, std::size_t) {

--- a/plugins/offload_vio/server_rx/CMakeLists.txt
+++ b/plugins/offload_vio/server_rx/CMakeLists.txt
@@ -32,7 +32,6 @@ PROTOBUF_TARGET_CPP(${PLUGIN_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../proto ${protob
 target_link_libraries(${PLUGIN_NAME}
         ${OpenCV_LIBS}
         protobuf::libprotobuf
-        spdlog::spdlog
         )
 
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)

--- a/plugins/offload_vio/server_rx/plugin.cpp
+++ b/plugins/offload_vio/server_rx/plugin.cpp
@@ -52,15 +52,15 @@ public:
             _conn_signal.put(_conn_signal.allocate<connection_signal>(connection_signal{true}));
             socket.socket_listen();
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.server_rx]: Waiting for connection!");
-#endif
+    #endif
 #endif
             read_socket = new TCPSocket(socket.socket_accept()); /* Blocking operation, waiting for client to connect */
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.server_rx]: Connection is established with {}", read_socket->peer_address());
-#endif
+    #endif
 #endif
         } else {
             std::string delimitter = "EEND!";

--- a/plugins/offload_vio/server_rx/plugin.cpp
+++ b/plugins/offload_vio/server_rx/plugin.cpp
@@ -35,7 +35,9 @@ public:
         , server_ip(SERVER_IP)
         , server_port(SERVER_PORT_1)
         , buffer_str("") {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+#endif
         socket.socket_set_reuseaddr();
         socket.socket_bind(server_ip, server_port);
         socket.enable_no_delay();
@@ -50,11 +52,15 @@ public:
             _conn_signal.put(_conn_signal.allocate<connection_signal>(connection_signal{true}));
             socket.socket_listen();
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.server_rx]: Waiting for connection!");
+#endif
 #endif
             read_socket = new TCPSocket(socket.socket_accept()); /* Blocking operation, waiting for client to connect */
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("[offload_vio.server_rx]: Connection is established with {}", read_socket->peer_address());
+#endif
 #endif
         } else {
             std::string delimitter = "EEND!";
@@ -69,8 +75,10 @@ public:
                     vio_input_proto::IMUCamVec vio_input;
                     bool                       success = vio_input.ParseFromString(before);
                     if (!success) {
+#ifdef USE_SPDLOGGER
                         spdlog::get(name)->error("[offload_vio.server_rx]Error parsing the protobuf, vio input size = {}",
                                                  before.size());
+#endif
                     } else {
                         ReceiveVioInput(vio_input);
                     }

--- a/plugins/offload_vio/server_tx/CMakeLists.txt
+++ b/plugins/offload_vio/server_tx/CMakeLists.txt
@@ -21,10 +21,10 @@ set(protobuf_files
 target_include_directories(${PLUGIN_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${Protobuf_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include)
 
 PROTOBUF_TARGET_CPP(${PLUGIN_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../proto ${protobuf_files})
-target_link_libraries(${PLUGIN_NAME}
-        protobuf::libprotobuf
-        spdlog::spdlog
-        )
+target_link_libraries(${PLUGIN_NAME} protobuf::libprotobuf)
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 

--- a/plugins/offload_vio/server_tx/plugin.cpp
+++ b/plugins/offload_vio/server_tx/plugin.cpp
@@ -21,7 +21,9 @@ public:
         , _m_imu_int_input{sb->get_reader<imu_integrator_input>("imu_integrator_input")}
         , client_ip(CLIENT_IP)
         , client_port(CLIENT_PORT_2) {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+#endif
         socket.socket_set_reuseaddr();
         socket.socket_bind(SERVER_IP, SERVER_PORT_2);
         socket.enable_no_delay();
@@ -45,11 +47,15 @@ public:
     void start_accepting_connection(switchboard::ptr<const connection_signal> datum) {
         socket.socket_listen();
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.server_tx]: Waiting for connection!");
+#endif
 #endif
         write_socket = new TCPSocket(socket.socket_accept()); /* Blocking operation, waiting for client to connect */
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.server_tx]: Connection is established with {}", write_socket->peer_address());
+#endif
 #endif
     }
 
@@ -143,7 +149,9 @@ public:
 
             delete vio_output_params;
         } else {
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->error("[offload_vio.server_tx] ERROR: write_socket is not yet created!");
+#endif
         }
     }
 

--- a/plugins/offload_vio/server_tx/plugin.cpp
+++ b/plugins/offload_vio/server_tx/plugin.cpp
@@ -47,15 +47,15 @@ public:
     void start_accepting_connection(switchboard::ptr<const connection_signal> datum) {
         socket.socket_listen();
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.server_tx]: Waiting for connection!");
-#endif
+    #endif
 #endif
         write_socket = new TCPSocket(socket.socket_accept()); /* Blocking operation, waiting for client to connect */
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("[offload_vio.server_tx]: Connection is established with {}", write_socket->peer_address());
-#endif
+    #endif
 #endif
     }
 

--- a/plugins/openni/CMakeLists.txt
+++ b/plugins/openni/CMakeLists.txt
@@ -18,7 +18,10 @@ if(BUILD_OPENCV)
 endif()
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${OpenCV_INCLUDE_DIRS} ${libopenni2_INCLUDE_DIR})
-target_link_libraries(${PLUGIN_NAME} ${OpenCV_LIBRARIES} ${libopenni2_LIBRARY} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${OpenCV_LIBRARIES} ${libopenni2_LIBRARY})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/openni/plugin.cpp
+++ b/plugins/openni/plugin.cpp
@@ -111,10 +111,10 @@ protected:
         const openni::Array<openni::VideoMode>& modesDepth = depthInfo->getSupportedVideoModes();
 #ifndef NDEBUG
         for (int i = 0; i < modesDepth.getSize(); i++) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("Depth Mode {}: {}x{}, {} fps, {} format", i, modesDepth[i].getResolutionX(),
                                      modesDepth[i].getResolutionY(), modesDepth[i].getFps(), modesDepth[i].getPixelFormat());
-#endif
+    #endif
         }
 #endif
         _device_status = _depth.setVideoMode(modesDepth[DEPTH_MODE]);
@@ -133,10 +133,10 @@ protected:
         // create _color channel
         _device_status = _color.create(_device, openni::SENSOR_COLOR);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         if (_device_status != openni::STATUS_OK)
             spdlog::get(name)->debug("Couldn't find color stream:\n{}", openni::OpenNI::getExtendedError());
-#endif
+    #endif
 #endif
 
         // get _color options
@@ -144,10 +144,10 @@ protected:
         const openni::Array<openni::VideoMode>& modesColor = colorInfo->getSupportedVideoModes();
 #ifndef NDEBUG
         for (int i = 0; i < modesColor.getSize(); i++) {
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("Color Mode {}: {}x{}, {} fps, {} format", i, modesColor[i].getResolutionX(),
                                      modesColor[i].getResolutionY(), modesColor[i].getFps(), modesColor[i].getPixelFormat());
-#endif
+    #endif
         }
 #endif
         _device_status = _color.setVideoMode(modesColor[RGB_MODE]);
@@ -158,10 +158,10 @@ protected:
         // start _color stream
         _device_status = _color.start();
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         if (_device_status != openni::STATUS_OK)
             spdlog::get(name)->debug("Couldn't start color stream:\n{}", openni::OpenNI::getExtendedError());
-#endif
+    #endif
 #endif
         int min_fps = std::min(modesColor[RGB_MODE].getFps(), modesDepth[DEPTH_MODE].getFps());
         _time_sleep = static_cast<uint64_t>((1.0f / static_cast<float>(min_fps)) * 1000);

--- a/plugins/pose_lookup/CMakeLists.txt
+++ b/plugins/pose_lookup/CMakeLists.txt
@@ -16,7 +16,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
         )
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/pose_lookup/data_loading.hpp
+++ b/plugins/pose_lookup/data_loading.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 // timestamp

--- a/plugins/pose_lookup/data_loading.hpp
+++ b/plugins/pose_lookup/data_loading.hpp
@@ -7,8 +7,11 @@
 #include <fstream>
 #include <iostream>
 #include <map>
-#include <spdlog/spdlog.h>
 #include <string>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 // timestamp
 // p_RS_R_x [m], p_RS_R_y [m], p_RS_R_z [m]
@@ -33,9 +36,11 @@ static std::map<ullong, sensor_types> load_data() {
     std::ifstream gt_file{illixr_data + "/state_groundtruth_estimate0/data.csv"};
 
     if (!gt_file.good()) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->error("[poselookup] ${ILLIXR_DATA}/state_groundtruth_estimate0/data.csv "
                                      "({})/state_groundtruth_estimate0/data.csv) is not a good path",
                                      illixr_data);
+#endif
         ILLIXR::abort();
     }
 

--- a/plugins/pose_lookup/plugin.cpp
+++ b/plugins/pose_lookup/plugin.cpp
@@ -41,7 +41,9 @@ public:
         const switchboard::ptr<const switchboard::event_wrapper<time_point>> estimated_vsync =
             _m_vsync_estimate.get_ro_nullable();
         if (estimated_vsync == nullptr) {
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->warn("[pose_lookup] Vsync estimation not valid yet, returning fast_pose for now()");
+#endif
             return get_fast_pose(_m_clock->now());
         } else {
             return get_fast_pose(**estimated_vsync);
@@ -129,16 +131,20 @@ public:
 
         if (nearest_row == _m_sensor_data.cend()) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[pose_lookup] Time {} ({} + {}) after last datum {}", lookup_time,
                                          std::chrono::nanoseconds(time.time_since_epoch()).count(), dataset_first_time,
                                          _m_sensor_data.rbegin()->first);
 #endif
+#endif
             nearest_row--;
         } else if (nearest_row == _m_sensor_data.cbegin()) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[pose_lookup] Time {} ({} + {}) before first datum {}", lookup_time,
                                          std::chrono::nanoseconds(time.time_since_epoch()).count(), dataset_first_time,
                                          _m_sensor_data.cbegin()->first);
+#endif
 #endif
         } else {
             // "std::map::upper_bound" returns an iterator to the first pair whose key is GREATER than the argument.

--- a/plugins/pose_lookup/plugin.cpp
+++ b/plugins/pose_lookup/plugin.cpp
@@ -131,20 +131,20 @@ public:
 
         if (nearest_row == _m_sensor_data.cend()) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[pose_lookup] Time {} ({} + {}) after last datum {}", lookup_time,
                                          std::chrono::nanoseconds(time.time_since_epoch()).count(), dataset_first_time,
                                          _m_sensor_data.rbegin()->first);
-#endif
+    #endif
 #endif
             nearest_row--;
         } else if (nearest_row == _m_sensor_data.cbegin()) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[pose_lookup] Time {} ({} + {}) before first datum {}", lookup_time,
                                          std::chrono::nanoseconds(time.time_since_epoch()).count(), dataset_first_time,
                                          _m_sensor_data.cbegin()->first);
-#endif
+    #endif
 #endif
         } else {
             // "std::map::upper_bound" returns an iterator to the first pair whose key is GREATER than the argument.

--- a/plugins/pose_prediction/CMakeLists.txt
+++ b/plugins/pose_prediction/CMakeLists.txt
@@ -11,7 +11,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
         )
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/pose_prediction/plugin.cpp
+++ b/plugins/pose_prediction/plugin.cpp
@@ -73,9 +73,9 @@ public:
         switchboard::ptr<const imu_raw_type> imu_raw = _m_imu_raw.get_ro_nullable();
         if (imu_raw == nullptr) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[POSEPREDICTION] FAST POSE IS SLOW POSE!");
-#endif
+    #endif
 #endif
             // No imu_raw, return slow_pose
             return fast_pose_type{

--- a/plugins/pose_prediction/plugin.cpp
+++ b/plugins/pose_prediction/plugin.cpp
@@ -73,7 +73,9 @@ public:
         switchboard::ptr<const imu_raw_type> imu_raw = _m_imu_raw.get_ro_nullable();
         if (imu_raw == nullptr) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get("illixr")->debug("[POSEPREDICTION] FAST POSE IS SLOW POSE!");
+#endif
 #endif
             // No imu_raw, return slow_pose
             return fast_pose_type{

--- a/plugins/realsense/CMakeLists.txt
+++ b/plugins/realsense/CMakeLists.txt
@@ -20,7 +20,10 @@ endif()
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${OpenCV_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${realsense2_INCLUDE_DIR} ${ILLIXR_SOURCE_DIR}/include)
 add_definitions(-Wno-format-extra-args)
-target_link_libraries(${PLUGIN_NAME} ${DEPENDENCIES} ${OpenCV_LIBRARIES} ${realsense2_LIBRARY} ${Eigen3_LIBRATIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${DEPENDENCIES} ${OpenCV_LIBRARIES} ${realsense2_LIBRARY} ${Eigen3_LIBRATIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/realsense/plugin.cpp
+++ b/plugins/realsense/plugin.cpp
@@ -38,7 +38,9 @@ public:
         , _m_cam{sb->get_writer<cam_type>("cam")}
         , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")}
         , realsense_cam{ILLIXR::getenv_or("REALSENSE_CAM", "auto")} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("REALSENSE_LOG_LEVEL"));
+#endif
         accel_data.iteration = -1;
         cfg.disable_all_streams();
         configure_camera();
@@ -178,11 +180,15 @@ private:
             if (device.supports(RS2_CAMERA_INFO_PRODUCT_LINE)) {
                 std::string product_line = device.get_info(RS2_CAMERA_INFO_PRODUCT_LINE);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Found Product Line: {}", product_line);
+#endif
 #endif
                 if (product_line == "D400") {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                     spdlog::get(name)->debug("Checking for supported streams");
+#endif
 #endif
                     std::vector<rs2::sensor> sensors = device.query_sensors();
                     for (const rs2::sensor& sensor : sensors) {
@@ -201,20 +207,26 @@ private:
                     if (accel_found && gyro_found) {
                         D4XXI_found = true;
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                         spdlog::get(name)->debug("Supported D4XX found!");
+#endif
 #endif
                     }
                 } else if (product_line == "T200") {
                     T26X_found = true;
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                     spdlog::get(name)->debug("T26X found!");
+#endif
 #endif
                 }
             }
         }
         if (!T26X_found && !D4XXI_found) {
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->warn("No supported Realsense device detected!");
+#endif
 #endif
         }
     }
@@ -229,23 +241,31 @@ private:
             if (D4XXI_found) {
                 cam_select = D4XXI;
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Setting cam_select: D4XX");
+#endif
 #endif
             } else if (T26X_found) {
                 cam_select = T26X;
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Setting cam_select: T26X");
+#endif
 #endif
             }
         } else if ((realsense_cam == "D4XX") && D4XXI_found) {
             cam_select = D4XXI;
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("Setting cam_select: D4XX");
+#endif
 #endif
         } else if ((realsense_cam == "T26X") && T26X_found) {
             cam_select = T26X;
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("Setting cam_select: T26X");
+#endif
 #endif
         }
         if (cam_select == UNSUPPORTED) {

--- a/plugins/realsense/plugin.cpp
+++ b/plugins/realsense/plugin.cpp
@@ -180,15 +180,15 @@ private:
             if (device.supports(RS2_CAMERA_INFO_PRODUCT_LINE)) {
                 std::string product_line = device.get_info(RS2_CAMERA_INFO_PRODUCT_LINE);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Found Product Line: {}", product_line);
-#endif
+    #endif
 #endif
                 if (product_line == "D400") {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                     spdlog::get(name)->debug("Checking for supported streams");
-#endif
+    #endif
 #endif
                     std::vector<rs2::sensor> sensors = device.query_sensors();
                     for (const rs2::sensor& sensor : sensors) {
@@ -207,26 +207,26 @@ private:
                     if (accel_found && gyro_found) {
                         D4XXI_found = true;
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                         spdlog::get(name)->debug("Supported D4XX found!");
-#endif
+    #endif
 #endif
                     }
                 } else if (product_line == "T200") {
                     T26X_found = true;
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                     spdlog::get(name)->debug("T26X found!");
-#endif
+    #endif
 #endif
                 }
             }
         }
         if (!T26X_found && !D4XXI_found) {
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->warn("No supported Realsense device detected!");
-#endif
+    #endif
 #endif
         }
     }
@@ -241,31 +241,31 @@ private:
             if (D4XXI_found) {
                 cam_select = D4XXI;
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Setting cam_select: D4XX");
-#endif
+    #endif
 #endif
             } else if (T26X_found) {
                 cam_select = T26X;
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
                 spdlog::get(name)->debug("Setting cam_select: T26X");
-#endif
+    #endif
 #endif
             }
         } else if ((realsense_cam == "D4XX") && D4XXI_found) {
             cam_select = D4XXI;
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("Setting cam_select: D4XX");
-#endif
+    #endif
 #endif
         } else if ((realsense_cam == "T26X") && T26X_found) {
             cam_select = T26X;
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
             spdlog::get(name)->debug("Setting cam_select: T26X");
-#endif
+    #endif
 #endif
         }
         if (cam_select == UNSUPPORTED) {

--- a/plugins/timewarp_gl/CMakeLists.txt
+++ b/plugins/timewarp_gl/CMakeLists.txt
@@ -26,7 +26,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
         )
 
 target_include_directories(${PLUGIN_NAME} PRIVATE ${X11_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} ${GLU_INCLUDE_DIR} ${gl_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include ${Eigen3_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${glu_LDFLAGS} ${gl_LIBRARIES} ${Eigen3_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${glu_LDFLAGS} ${gl_LIBRARIES} ${Eigen3_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE -DUSE_GL)
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/timewarp_gl/plugin.cpp
+++ b/plugins/timewarp_gl/plugin.cpp
@@ -314,9 +314,9 @@ private:
 
 #ifndef NDEBUG
         double time = duration2double<std::milli>(offload_duration);
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Texture image collecting time: {} ms", time);
-#endif
+    #endif
 #endif
 
         return pixels;
@@ -841,7 +841,7 @@ public:
     #ifndef NDEBUG // Timewarp only has vsync estimates if we're running with native-gl
 
         if (log_count > LOG_PERIOD) {
-#ifdef USE_SPDLOGGER
+        #ifdef USE_SPDLOGGER
             const double     time_swap         = duration2double<std::milli>(time_after_swap - time_before_swap);
             const double     latency_mtd       = duration2double<std::milli>(imu_to_display);
             const double     latency_ptd       = duration2double<std::milli>(predict_to_display);
@@ -854,7 +854,7 @@ public:
             spdlog::get(name)->debug("Prediction-to-display latency: {} ms", latency_ptd);
             spdlog::get(name)->debug("Render-to-display latency: {} ms", latency_rtd);
             spdlog::get(name)->debug("Next swap in: {} ms in the future", timewarp_estimate);
-#endif
+        #endif
         }
     #endif
 

--- a/plugins/timewarp_gl/plugin.cpp
+++ b/plugins/timewarp_gl/plugin.cpp
@@ -84,7 +84,9 @@ public:
 #endif
         , timewarp_gpu_logger{record_logger_}
         , _m_hologram{sb->get_writer<hologram_input>("hologram_in")} {
+#ifdef USE_SPDLOGGER
         spdlogger(std::getenv("TIMEWARP_GL_LOG_LEVEL"));
+#endif
 #ifndef ILLIXR_MONADO
         const std::shared_ptr<xlib_gl_extended_window> xwin = pb->lookup_impl<xlib_gl_extended_window>();
         dpy                                                 = xwin->dpy;
@@ -152,7 +154,9 @@ public:
             }
 #endif
             default: {
+#ifdef USE_SPDLOGGER
                 spdlog::get(name)->warn("Invalid swapchain usage provided");
+#endif
                 break;
             }
             }
@@ -310,7 +314,9 @@ private:
 
 #ifndef NDEBUG
         double time = duration2double<std::milli>(offload_duration);
+#ifdef USE_SPDLOGGER
         spdlog::get(name)->debug("Texture image collecting time: {} ms", time);
+#endif
 #endif
 
         return pixels;
@@ -519,7 +525,9 @@ public:
         glewExperimental      = GL_TRUE;
         const GLenum glew_err = glewInit();
         if (glew_err != GLEW_OK) {
+#ifdef USE_SPDLOGGER
             spdlog::get(name)->error("[timewarp_gl] GLEW Error: {}", glewGetErrorString(glew_err));
+#endif
             ILLIXR::abort("[timewarp_gl] Failed to initialize GLEW");
         }
 
@@ -833,6 +841,7 @@ public:
     #ifndef NDEBUG // Timewarp only has vsync estimates if we're running with native-gl
 
         if (log_count > LOG_PERIOD) {
+#ifdef USE_SPDLOGGER
             const double     time_swap         = duration2double<std::milli>(time_after_swap - time_before_swap);
             const double     latency_mtd       = duration2double<std::milli>(imu_to_display);
             const double     latency_ptd       = duration2double<std::milli>(predict_to_display);
@@ -845,6 +854,7 @@ public:
             spdlog::get(name)->debug("Prediction-to-display latency: {} ms", latency_ptd);
             spdlog::get(name)->debug("Render-to-display latency: {} ms", latency_rtd);
             spdlog::get(name)->debug("Next swap in: {} ms in the future", timewarp_estimate);
+#endif
         }
     #endif
 

--- a/plugins/timewarp_vk/CMakeLists.txt
+++ b/plugins/timewarp_vk/CMakeLists.txt
@@ -54,7 +54,10 @@ add_dependencies(${PLUGIN_NAME} Timewarp_VK_Shaders)
 
 set_target_properties(${PLUGIN_NAME} PROPERTIES OUTPUT_NAME ${PLUGIN_NAME})
 
-target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_include_directories(${PLUGIN_NAME} PUBLIC ${Vulkan_INCLUDE_DIRS})
 target_include_directories(${PLUGIN_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${ILLIXR_SOURCE_DIR}/include)
 

--- a/plugins/vkdemo/CMakeLists.txt
+++ b/plugins/vkdemo/CMakeLists.txt
@@ -48,7 +48,10 @@ add_library(${PLUGIN_NAME} SHARED plugin.cpp
 add_dependencies(${PLUGIN_NAME} Vkdemo_Shaders)
 set_target_properties(${PLUGIN_NAME} PROPERTIES OUTPUT_NAME ${PLUGIN_NAME})
 
-target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES} spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${Vulkan_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_include_directories(${PLUGIN_NAME} PUBLIC ${Vulkan_INCLUDE_DIRS} ${ILLIXR_SOURCE_DIR}/include)
 
 install_shaders(SPIRV_BINARY_FILES vkdemo ${PLUGIN_NAME})

--- a/plugins/vkdemo/plugin.cpp
+++ b/plugins/vkdemo/plugin.cpp
@@ -407,10 +407,10 @@ private:
         int  width, height, channels;
         auto data = stbi_load(path.c_str(), &width, &height, &channels, 0);
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[vkdemo] Loaded texture {} with dimensions {}x{} and {} channels", path, width, height,
                                      channels);
-#endif
+    #endif
 #endif
         if (data == nullptr) {
             throw std::runtime_error("Failed to load texture image!");
@@ -596,9 +596,9 @@ private:
         }
 
 #ifndef NDEBUG
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[vkdemo] Loaded {} textures", textures.size());
-#endif
+    #endif
 #endif
 
         std::unordered_map<Vertex, uint32_t> unique_vertices{};

--- a/plugins/vkdemo/plugin.cpp
+++ b/plugins/vkdemo/plugin.cpp
@@ -407,8 +407,10 @@ private:
         int  width, height, channels;
         auto data = stbi_load(path.c_str(), &width, &height, &channels, 0);
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[vkdemo] Loaded texture {} with dimensions {}x{} and {} channels", path, width, height,
                                      channels);
+#endif
 #endif
         if (data == nullptr) {
             throw std::runtime_error("Failed to load texture image!");
@@ -594,7 +596,9 @@ private:
         }
 
 #ifndef NDEBUG
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[vkdemo] Loaded {} textures", textures.size());
+#endif
 #endif
 
         std::unordered_map<Vertex, uint32_t> unique_vertices{};

--- a/plugins/zed/CMakeLists.txt
+++ b/plugins/zed/CMakeLists.txt
@@ -27,7 +27,10 @@ endif()
 
 target_include_directories(${PLUGIN_NAME} PUBLIC ${CUDA_INCLUDE_DIRS} ${ZED_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(${PLUGIN_NAME} ${ZED_LIBS} ${OpenCV_LIBRARIES} ${Eigen3_LIBRARIES} Threads::Threads spdlog::spdlog)
+target_link_libraries(${PLUGIN_NAME} ${ZED_LIBS} ${OpenCV_LIBRARIES} ${Eigen3_LIBRARIES} Threads::Threads)
+if(USE_SPDLOGGER)
+target_link_libraries(${PLUGIN_NAME} spdlog::spdlog)
+endif()
 target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 install(TARGETS ${PLUGIN_NAME} DESTINATION lib)

--- a/plugins/zed/plugin.cpp
+++ b/plugins/zed/plugin.cpp
@@ -61,7 +61,9 @@ std::shared_ptr<Camera> start_camera() {
     // Open the camera
     ERROR_CODE err = zedm->open(init_params);
     if (err != ERROR_CODE::SUCCESS) {
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->info("[zed] {}", toString(err).c_str());
+#endif
         zedm->close();
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,10 @@ target_include_directories(main${ILLIXR_BUILD_SUFFIX}.exe PUBLIC ${CMAKE_SOURCE_
 target_link_libraries(main${ILLIXR_BUILD_SUFFIX}.exe dl stdc++fs plugin.main${ILLIXR_BUILD_SUFFIX})
 
 target_include_directories(plugin.main${ILLIXR_BUILD_SUFFIX} PUBLIC ${X11_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} ${SQLite3_INCLUDE_DIR} ${GLU_INCLUDE_DIR} ${gl_INCLUDE_DIRS} ${yaml-cpp_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(plugin.main${ILLIXR_BUILD_SUFFIX} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${SQLite3_LIBRARIES} ${glu_LDFLAGS} ${gl_LIBRARIES} dl Threads::Threads stdc++fs ${yaml-cpp_LIBRARIES} spdlog::spdlog)
+target_link_libraries(plugin.main${ILLIXR_BUILD_SUFFIX} ${X11_LIBRARIES} ${GLEW_LIBRARIES} ${SQLite3_LIBRARIES} ${glu_LDFLAGS} ${gl_LIBRARIES} dl Threads::Threads stdc++fs ${yaml-cpp_LIBRARIES})
+if(USE_SPDLOGGER)
+target_link_libraries(plugin.main${ILLIXR_BUILD_SUFFIX} spdlog::spdlog)
+endif()
 
 install(TARGETS main${ILLIXR_BUILD_SUFFIX}.exe DESTINATION bin)
 install(TARGETS plugin.main${ILLIXR_BUILD_SUFFIX} DESTINATION lib)

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -24,11 +24,15 @@ int ILLIXR::run(const cxxopts::ParseResult& options) {
     const bool enable_pre_sleep = ILLIXR::str_to_bool(getenv_or("ILLIXR_ENABLE_PRE_SLEEP", "False"));
     if (enable_pre_sleep) {
         const pid_t pid = getpid();
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->info("[main] Pre-sleep enabled.");
         spdlog::get("illixr")->info("[main] PID: {}", pid);
         spdlog::get("illixr")->info("[main] Sleeping for {} seconds...", ILLIXR_PRE_SLEEP_DURATION);
+#endif
         sleep(ILLIXR_PRE_SLEEP_DURATION);
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->info("[main] Resuming...");
+#endif
     }
 #endif /// NDEBUG
     // read in yaml config file

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -24,15 +24,15 @@ int ILLIXR::run(const cxxopts::ParseResult& options) {
     const bool enable_pre_sleep = ILLIXR::str_to_bool(getenv_or("ILLIXR_ENABLE_PRE_SLEEP", "False"));
     if (enable_pre_sleep) {
         const pid_t pid = getpid();
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->info("[main] Pre-sleep enabled.");
         spdlog::get("illixr")->info("[main] PID: {}", pid);
         spdlog::get("illixr")->info("[main] Sleeping for {} seconds...", ILLIXR_PRE_SLEEP_DURATION);
-#endif
+    #endif
         sleep(ILLIXR_PRE_SLEEP_DURATION);
-#ifdef USE_SPDLOGGER
+    #ifdef USE_SPDLOGGER
         spdlog::get("illixr")->info("[main] Resuming...");
-#endif
+    #endif
     }
 #endif /// NDEBUG
     // read in yaml config file

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -14,14 +14,18 @@
 #include <algorithm>
 #include <GL/glx.h>
 #include <memory>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
 
+#ifdef USE_SPDLOGGER
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+#endif
+
 using namespace ILLIXR;
 
+#ifdef USE_SPDLOGGER
 void spdlogger(const std::string& name, const char* log_level) {
     if (!log_level) {
 #ifdef NDEBUG
@@ -37,11 +41,14 @@ void spdlogger(const std::string& name, const char* log_level) {
     logger->set_level(spdlog::level::from_str(log_level));
     spdlog::register_logger(logger);
 }
+#endif
 
 class runtime_impl : public runtime {
 public:
     explicit runtime_impl() {
+#ifdef USE_SPDLOGGER
         spdlogger("illixr", std::getenv("ILLIXR_LOG_LEVEL"));
+#endif
         pb.register_impl<record_logger>(std::make_shared<sqlite_record_logger>());
         pb.register_impl<gen_guid>(std::make_shared<gen_guid>());
         pb.register_impl<switchboard>(std::make_shared<switchboard>(&pb));

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -18,9 +18,9 @@
 #include <vector>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
+    #include <spdlog/sinks/basic_file_sink.h>
+    #include <spdlog/sinks/stdout_color_sinks.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 using namespace ILLIXR;
@@ -28,11 +28,11 @@ using namespace ILLIXR;
 #ifdef USE_SPDLOGGER
 void spdlogger(const std::string& name, const char* log_level) {
     if (!log_level) {
-#ifdef NDEBUG
+    #ifdef NDEBUG
         log_level = "warn";
-#else
+    #else
         log_level = "debug";
-#endif
+    #endif
     }
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());

--- a/src/sqlite_record_logger.hpp
+++ b/src/sqlite_record_logger.hpp
@@ -10,8 +10,11 @@
 #include <iostream>
 #include <mutex>
 #include <shared_mutex>
-#include <spdlog/spdlog.h>
 #include <thread>
+
+#ifdef USE_SPDLOGGER
+#include <spdlog/spdlog.h>
+#endif
 
 /**
  * There are many SQLite3 wrapper libraries.
@@ -101,9 +104,11 @@ public:
         std::vector<record> record_batch{max_record_batch_size};
         std::size_t         actual_batch_size;
 
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%^%l%$] [sqlite_record_logger] thread %t %v");
         spdlog::get("illixr")->debug("{}", table_name);
         spdlog::get("illixr")->set_pattern("%+");
+#endif
 
         std::size_t processed = 0;
         while (!terminate.load()) {
@@ -125,8 +130,10 @@ public:
             process(record_batch, actual_batch_size);
             post_processed += actual_batch_size;
         }
+#ifdef USE_SPDLOGGER
         spdlog::get("illixr")->debug("[sqlite_record_logger] Drained {} (sqlite); {}/{} done post real time", table_name,
                                      post_processed, (processed + post_processed));
+#endif
     }
 
     void process(const std::vector<record>& record_batch, std::size_t batch_size) {

--- a/src/sqlite_record_logger.hpp
+++ b/src/sqlite_record_logger.hpp
@@ -13,7 +13,7 @@
 #include <thread>
 
 #ifdef USE_SPDLOGGER
-#include <spdlog/spdlog.h>
+    #include <spdlog/spdlog.h>
 #endif
 
 /**


### PR DESCRIPTION
Mitigates SPD logger thread concurrency issue (#425).

In addition to the cited concurrency issue, the project does not build on a fresh Fedora 39/40 container image. Rather than replace the functionality with a new implementation of a logger, add an optional CMake build flag which toggles the inclusion of the spdlog library dependency.