### PR TITLE
converted env handling to use switchboard

### DIFF
--- a/cmake/GetAudio_Pipeline.cmake
+++ b/cmake/GetAudio_Pipeline.cmake
@@ -8,7 +8,7 @@ set(AUDIO_PIPELINE_CMAKE_ARGS "")
 
 ExternalProject_Add(Audio_Pipeline
         GIT_REPOSITORY https://github.com/ILLIXR/audio_pipeline.git   # Git repo for source code
-        GIT_TAG ebc2f04d0eca0792795db2c675c58fbdae42ab5f              # sha5 hash for specific commit to pull (if there is no specific tag to use)
+        GIT_TAG b832dc019ae31993842218dd3c3a70c677307491              # sha5 hash for specific commit to pull (if there is no specific tag to use)
         PREFIX ${CMAKE_BINARY_DIR}/_deps/audio_pipeline               # the build directory
         DEPENDS ${PortAudio_DEP_STR} ${SpatialAudio_DEP_STR} ${OpenCV_DEP_STR}  # dependencies of this module
         #arguments to pass to CMake

--- a/docs/docs/getting_started.md.in
+++ b/docs/docs/getting_started.md.in
@@ -181,6 +181,10 @@ Where the entries are defined as (* indicates required field):
 
 In general, you should not edit a [profile][23] file directly. The exception to this is when you are testing things on your own machine. [Profile][23] files are generated automatically from the master `profiles/plugins.yaml` during the cmake configuration stage. This is done so that any changes to a [profile][23] or the addition or removal of a [plugin][22] can be managed from a single file. The build system will generate an *illixr.yaml* file which contains entries from the command line and any input profile file and can be freely edited (it is generated every time `cmake` is called).
 
+## Environment Variables
+
+ILLIXR and several of its dependencies use environment variables to steer processing and define quasi-constant values. Traditionally, one would use std::getenv and std::setenv to get and set these items. However in ILLIXR the switchboard acts as an interface to these functions with get_env (returns std::string), get_env_bool (returns bool) get_env_char (returns char*) and set_env. Using the switchboard interfaces allows for environment variables to be set from the command line and/or yaml file. It is strongly encouraged to the the switchboard interface wherever possible.
+
 ## ILLIXR Graphics Backends
 
 ILLIXR currently supports both OpenGL and Vulkan backends (indicated as `gl` and `vk` in the config suffixes). Since some plugins should behave differently (and compile differently) based on what backend is being used, it's important to run `make clean` if you want to try swapping between the two backends.

--- a/docs/docs/logging_and_metrics.md
+++ b/docs/docs/logging_and_metrics.md
@@ -24,7 +24,7 @@ export ILLIXR_LOG_LEVEL=warn
 main.dbg.exe -yaml=profiles/native_gl.yaml
 ``` 
 
-When writing a new plugin, the `plugin.spdlogger(std::string log_level)` method should be called, e.g., using `std::getenv("<PLUGIN_NAME>_LOG_LEVEL")` This creates a logger with two sinks (console and file). This logger is then registered in the global spdlog registry. 
+When writing a new plugin, the `plugin.spdlogger(std::string log_level)` method should be called, e.g., using `switchboard->get_env("<PLUGIN_NAME>_LOG_LEVEL")` This creates a logger with two sinks (console and file). This logger is then registered in the global spdlog registry. 
 
 To log inside of a plugin method, use the plugin's name attribute to get the particular logger from the registry and call the desired log level method, e.g.
 ```

--- a/include/illixr/cpu_timer.hpp
+++ b/include/illixr/cpu_timer.hpp
@@ -158,7 +158,7 @@ static std::size_t gen_serial_no() {
 class should_profile_class {
 public:
     should_profile_class() {
-        const char* ILLIXR_STDOUT_METRICS = getenv("ILLIXR_STDOUT_METRICS");
+        const char* ILLIXR_STDOUT_METRICS = getenv("ILLIXR_STDOUT_METRICS");  // can't use switchboard interface here
         actually_should_profile           = ILLIXR_STDOUT_METRICS && (strcmp(ILLIXR_STDOUT_METRICS, "y") == 0);
     }
 

--- a/include/illixr/error_util.hpp
+++ b/include/illixr/error_util.hpp
@@ -27,8 +27,9 @@
 #endif /// RAC_ERRNO_MSG
 
 namespace ILLIXR {
-
-static const bool ENABLE_VERBOSE_ERRORS{ILLIXR::str_to_bool(ILLIXR::getenv_or("ILLIXR_ENABLE_VERBOSE_ERRORS", "False"))};
+// can't use switchboard interface here
+static const bool ENABLE_VERBOSE_ERRORS{getenv("ILLIXR_ENABLE_VERBOSE_ERRORS") != nullptr &&
+                                        ILLIXR::str_to_bool(getenv("ILLIXR_ENABLE_VERBOSE_ERRORS"))};
 
 /**
  * @brief Support function to report errno values when debugging (NDEBUG).

--- a/include/illixr/runtime.hpp
+++ b/include/illixr/runtime.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "illixr/phonebook.hpp"
+#include "illixr/switchboard.hpp"
 
 #include <GL/glx.h>
 #include <string>
@@ -28,6 +29,7 @@ public:
      */
     virtual void stop() = 0;
 
+    virtual std::shared_ptr<switchboard> get_switchboard() = 0;
     virtual ~runtime() = default;
 };
 

--- a/plugins/debugview/plugin.cpp
+++ b/plugins/debugview/plugin.cpp
@@ -66,7 +66,7 @@ public:
         , _m_fast_pose{sb->get_reader<imu_raw_type>("imu_raw")} //, glfw_context{pb->lookup_impl<global_config>()->glfw_context}
         , _m_rgb_depth(sb->get_reader<rgb_depth_type>("rgb_depth"))
         , _m_cam{sb->get_buffered_reader<cam_type>("cam")} {
-        spdlogger(std::getenv("DEBUGVIEW_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("DEBUGVIEW_LOG_LEVEL"));
     }
 
     void draw_GUI() {
@@ -512,7 +512,7 @@ public:
         // Init and verify GLEW
         const GLenum glew_err = glewInit();
         if (glew_err != GLEW_OK) {
-            spdlog::get(name)->error("GLEW Error: {}", glewGetErrorString(glew_err));
+            spdlog::get(name)->error("GLEW Error: {}", reinterpret_cast<const char*>(glewGetErrorString(glew_err)));
             glfwDestroyWindow(gui_window);
             ILLIXR::abort("[debugview] Failed to initialize GLEW");
         }
@@ -546,13 +546,13 @@ public:
         RAC_ERRNO_MSG("debugview after glGetUniformLocation");
 
         // Load/initialize the demo scene.
-        char* obj_dir = std::getenv("ILLIXR_DEMO_DATA");
-        if (obj_dir == nullptr) {
+        const std::string obj_dir = sb->get_env("ILLIXR_DEMO_DATA");
+        if (obj_dir.empty()) {
             ILLIXR::abort("Please define ILLIXR_DEMO_DATA.");
         }
 
-        demoscene = ObjScene(std::string(obj_dir), "scene.obj");
-        headset   = ObjScene(std::string(obj_dir), "headset.obj");
+        demoscene = ObjScene(obj_dir, "scene.obj");
+        headset   = ObjScene(obj_dir, "headset.obj");
 
         // Generate fun test pattern for missing camera images.
         for (unsigned x = 0; x < TEST_PATTERN_WIDTH; x++) {

--- a/plugins/depthai/plugin.cpp
+++ b/plugins/depthai/plugin.cpp
@@ -30,7 +30,7 @@ public:
         , _m_cam{sb->get_writer<cam_type>("cam")}
         , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")} // Initialize DepthAI pipeline and device
         , device{createCameraPipeline()} {
-        spdlogger(std::getenv("DEPTHAI_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("DEPTHAI_LOG_LEVEL"));
 #ifndef NDEBUG
         spdlog::get(name)->debug("pipeline started");
 #endif

--- a/plugins/fauxpose/plugin.cpp
+++ b/plugins/fauxpose/plugin.cpp
@@ -52,7 +52,7 @@ public:
         : sb{pb->lookup_impl<switchboard>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , _m_vsync_estimate{sb->get_reader<switchboard::event_wrapper<time_point>>("vsync_estimate")} {
-        char* env_input; /* pointer to environment variable input */
+        const char* env_input; /* pointer to environment variable input */
 #ifndef NDEBUG
         spdlog::get("illixr")->debug("[fauxpose] Starting Service");
 #endif
@@ -75,13 +75,13 @@ public:
         amplitude       = 2.0;
 
         // Adjust parameters based on environment variables
-        if ((env_input = getenv("FAUXPOSE_PERIOD"))) {
+        if ((env_input = sb->get_env_char("FAUXPOSE_PERIOD"))) {
             period = std::strtof(env_input, nullptr);
         }
-        if ((env_input = getenv("FAUXPOSE_AMPLITUDE"))) {
+        if ((env_input = sb->get_env_char("FAUXPOSE_AMPLITUDE"))) {
             amplitude = std::strtof(env_input, nullptr);
         }
-        if ((env_input = getenv("FAUXPOSE_CENTER"))) {
+        if ((env_input = sb->get_env_char("FAUXPOSE_CENTER"))) {
             center_location[0] = std::strtof(env_input, nullptr);
             center_location[1] = std::strtof(strchrnul(env_input, ',') + 1, nullptr);
             center_location[2] = std::strtof(strchrnul(strchrnul(env_input, ',') + 1, ',') + 1, nullptr);

--- a/plugins/gldemo/plugin.cpp
+++ b/plugins/gldemo/plugin.cpp
@@ -44,7 +44,7 @@ public:
         , _m_vsync{sb->get_reader<switchboard::event_wrapper<time_point>>("vsync_estimate")}
         , _m_image_handle{sb->get_writer<image_handle>("image_handle")}
         , _m_eyebuffer{sb->get_writer<rendered_frame>("eyebuffer")} {
-        spdlogger(std::getenv("GLDEMO_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("GLDEMO_LOG_LEVEL"));
     }
 
     // Essentially, a crude equivalent of XRWaitFrame.
@@ -299,7 +299,7 @@ public:
         // Init and verify GLEW
         const GLenum glew_err = glewInit();
         if (glew_err != GLEW_OK) {
-            spdlog::get(name)->error("GLEW Error: {}", glewGetErrorString(glew_err));
+            spdlog::get(name)->error("GLEW Error: {}", reinterpret_cast<const char*>(glewGetErrorString(glew_err)));
             ILLIXR::abort("Failed to initialize GLEW");
         }
 
@@ -333,12 +333,12 @@ public:
         colorUniform     = glGetUniformLocation(demoShaderProgram, "u_color");
 
         // Load/initialize the demo scene
-        char* obj_dir = std::getenv("ILLIXR_DEMO_DATA");
-        if (obj_dir == nullptr) {
+        std::string obj_dir = sb->get_env("ILLIXR_DEMO_DATA");
+        if (obj_dir.empty()) {
             ILLIXR::abort("Please define ILLIXR_DEMO_DATA.");
         }
 
-        demoscene = ObjScene(std::string(obj_dir), "scene.obj");
+        demoscene = ObjScene(obj_dir, "scene.obj");
 
         // Construct perspective projection matrix
         math_util::projection_fov(&basicProjection, display_params::fov_x / 2.0f, display_params::fov_x / 2.0f,

--- a/plugins/ground_truth_slam/data_loading.hpp
+++ b/plugins/ground_truth_slam/data_loading.hpp
@@ -22,13 +22,12 @@ using namespace ILLIXR;
 
 typedef pose_type sensor_types;
 
-static std::map<ullong, sensor_types> load_data() {
-    const char* illixr_data_c_str = std::getenv("ILLIXR_DATA");
-    if (!illixr_data_c_str) {
+static std::map<ullong, sensor_types> load_data(const std::shared_ptr<switchboard>& sb) {
+    const std::string illixr_data = sb->get_env("ILLIXR_DATA");
+    if (illixr_data.empty()) {
         ILLIXR::abort("Please define ILLIXR_DATA");
     }
     const std::string subpath     = "/state_groundtruth_estimate0/data.csv";
-    std::string       illixr_data = std::string{illixr_data_c_str};
 
     std::map<ullong, sensor_types> data;
 

--- a/plugins/ground_truth_slam/plugin.cpp
+++ b/plugins/ground_truth_slam/plugin.cpp
@@ -23,13 +23,13 @@ public:
         , sb{pb->lookup_impl<switchboard>()}
         , _m_true_pose{sb->get_writer<pose_type>("true_pose")}
         , _m_ground_truth_offset{sb->get_writer<switchboard::event_wrapper<Eigen::Vector3f>>("ground_truth_offset")}
-        , _m_sensor_data{load_data()}
+        , _m_sensor_data{load_data(sb)}
         // The relative-clock timestamp of each IMU is the difference between its dataset time and the IMU dataset_first_time.
         // Therefore we need the IMU dataset_first_time to reproduce the real dataset time.
         // TODO: Change the hardcoded number to be read from some configuration variables in the yaml file.
         , _m_dataset_first_time{ViconRoom1Medium}
         , _m_first_time{true} {
-        spdlogger(std::getenv("GROUND_TRUTH_SLAM_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("GROUND_TRUTH_SLAM_LOG_LEVEL"));
     }
 
     void start() override {

--- a/plugins/gtsam_integrator/plugin.cpp
+++ b/plugins/gtsam_integrator/plugin.cpp
@@ -29,7 +29,7 @@ public:
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , _m_imu_integrator_input{sb->get_reader<imu_integrator_input>("imu_integrator_input")}
         , _m_imu_raw{sb->get_writer<imu_raw_type>("imu_raw")} {
-        spdlogger(std::getenv("GTSAM_INTEGRATOR_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("GTSAM_INTEGRATOR_LOG_LEVEL"));
         sb->schedule<imu_type>(id, "imu", [&](const switchboard::ptr<const imu_type>& datum, size_t) {
             callback(datum);
         });

--- a/plugins/native_renderer/plugin.cpp
+++ b/plugins/native_renderer/plugin.cpp
@@ -32,7 +32,7 @@ public:
         , src{pb->lookup_impl<app>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , last_fps_update{std::chrono::duration<long, std::nano>{0}} {
-        spdlogger(std::getenv("NATIVE_RENDERER_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("NATIVE_RENDERER_LOG_LEVEL"));
     }
 
     /**

--- a/plugins/offline_cam/data_loading.hpp
+++ b/plugins/offline_cam/data_loading.hpp
@@ -52,13 +52,12 @@ typedef struct {
     lazy_load_image cam1;
 } sensor_types;
 
-static std::map<ullong, sensor_types> load_data() {
-    const char* illixr_data_c_str = std::getenv("ILLIXR_DATA");
-    if (!illixr_data_c_str) {
+static std::map<ullong, sensor_types> load_data(const std::shared_ptr<ILLIXR::switchboard>& sb) {
+    const std::string illixr_data = sb->get_env("ILLIXR_DATA");
+    if (illixr_data.empty()) {
         spdlog::get("illixr")->error("[offline_cam] Please define ILLIXR_DATA");
         ILLIXR::abort();
     }
-    std::string illixr_data = std::string{illixr_data_c_str};
 
     std::map<ullong, sensor_types> data;
 

--- a/plugins/offline_cam/plugin.cpp
+++ b/plugins/offline_cam/plugin.cpp
@@ -16,12 +16,12 @@ public:
         : threadloop{name_, pb_}
         , sb{pb->lookup_impl<switchboard>()}
         , _m_cam_publisher{sb->get_writer<cam_type>("cam")}
-        , _m_sensor_data{load_data()}
+        , _m_sensor_data{load_data(sb)}
         , dataset_first_time{_m_sensor_data.cbegin()->first}
         , last_ts{0}
         , _m_rtc{pb->lookup_impl<RelativeClock>()}
         , next_row{_m_sensor_data.cbegin()} {
-        spdlogger(std::getenv("OFFLINE_CAM_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("OFFLINE_CAM_LOG_LEVEL"));
     }
 
     skip_option _p_should_skip() override {

--- a/plugins/offline_imu/data_loading.hpp
+++ b/plugins/offline_imu/data_loading.hpp
@@ -20,13 +20,12 @@ typedef struct {
     raw_imu_type imu0;
 } sensor_types;
 
-static std::map<ullong, sensor_types> load_data() {
-    const char* illixr_data_c_str = std::getenv("ILLIXR_DATA");
-    if (!illixr_data_c_str) {
+static std::map<ullong, sensor_types> load_data(const std::shared_ptr<ILLIXR::switchboard>& sb) {
+    std::string illixr_data = sb->get_env("ILLIXR_DATA");
+    if (illixr_data.empty()) {
         spdlog::get("illixr")->error("[offline_imu] Please define ILLIXR_DATA");
         ILLIXR::abort();
     }
-    std::string illixr_data = std::string{illixr_data_c_str};
 
     std::map<ullong, sensor_types> data;
 

--- a/plugins/offline_imu/plugin.cpp
+++ b/plugins/offline_imu/plugin.cpp
@@ -14,9 +14,9 @@ class offline_imu : public ILLIXR::threadloop {
 public:
     offline_imu(const std::string& name_, phonebook* pb_)
         : threadloop{name_, pb_}
-        , _m_sensor_data{load_data()}
-        , _m_sensor_data_it{_m_sensor_data.cbegin()}
         , _m_sb{pb->lookup_impl<switchboard>()}
+        , _m_sensor_data{load_data(_m_sb)}
+        , _m_sensor_data_it{_m_sensor_data.cbegin()}
         , _m_imu{_m_sb->get_writer<imu_type>("imu")}
         , dataset_first_time{_m_sensor_data_it->first}
         , dataset_now{0}
@@ -50,9 +50,9 @@ protected:
     }
 
 private:
+    const std::shared_ptr<switchboard>             _m_sb;
     const std::map<ullong, sensor_types>           _m_sensor_data;
     std::map<ullong, sensor_types>::const_iterator _m_sensor_data_it;
-    const std::shared_ptr<switchboard>             _m_sb;
     switchboard::writer<imu_type>                  _m_imu;
 
     // Timestamp of the first IMU value from the dataset

--- a/plugins/offload_data/plugin.cpp
+++ b/plugins/offload_data/plugin.cpp
@@ -7,6 +7,7 @@
 #include "illixr/switchboard.hpp"
 
 #include <boost/filesystem.hpp>
+#include <fstream>
 #include <iostream>
 #include <numeric>
 #include <utility>
@@ -25,10 +26,10 @@ public:
         , sb{pb->lookup_impl<switchboard>()}
         , percent{0}
         , img_idx{0}
-        , enable_offload{ILLIXR::str_to_bool(ILLIXR::getenv_or("ILLIXR_OFFLOAD_ENABLE", "False"))}
+        , enable_offload{sb->get_env_bool("ILLIXR_OFFLOAD_ENABLE", "False")}
         , is_success{true} /// TODO: Set with #198
-        , obj_dir{ILLIXR::getenv_or("ILLIXR_OFFLOAD_PATH", "metrics/offloaded_data/")} {
-        spdlogger(std::getenv("OFFLOAD_DATA_LOG_LEVEL"));
+        , obj_dir{sb->get_env("ILLIXR_OFFLOAD_PATH", "metrics/offloaded_data/")} {
+        spdlogger(sb->get_env_char("OFFLOAD_DATA_LOG_LEVEL"));
         sb->schedule<texture_pose>(id, "texture_pose", [&](const switchboard::ptr<const texture_pose>& datum, size_t) {
             callback(datum);
         });

--- a/plugins/offload_vio/device_rx/plugin.cpp
+++ b/plugins/offload_vio/device_rx/plugin.cpp
@@ -20,7 +20,7 @@ public:
         , _m_imu_integrator_input{sb->get_writer<imu_integrator_input>("imu_integrator_input")}
         , server_ip(SERVER_IP)
         , server_port(SERVER_PORT_2) {
-        spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("OFFLOAD_VIO_LOG_LEVEL"));
         pose_type                   datum_pose_tmp{time_point{}, Eigen::Vector3f{0, 0, 0}, Eigen::Quaternionf{1, 0, 0, 0}};
         switchboard::ptr<pose_type> datum_pose = _m_pose.allocate<pose_type>(std::move(datum_pose_tmp));
         _m_pose.put(std::move(datum_pose));

--- a/plugins/offload_vio/device_tx/plugin.cpp
+++ b/plugins/offload_vio/device_tx/plugin.cpp
@@ -37,7 +37,7 @@ public:
         , _m_cam{sb->get_buffered_reader<cam_type>("cam")}
         , server_ip(SERVER_IP)
         , server_port(SERVER_PORT_1) {
-        spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("OFFLOAD_VIO_LOG_LEVEL"));
         socket.socket_set_reuseaddr();
         socket.socket_bind(CLIENT_IP, CLIENT_PORT_1);
         socket.enable_no_delay();

--- a/plugins/offload_vio/device_tx/video_encoder.cpp
+++ b/plugins/offload_vio/device_tx/video_encoder.cpp
@@ -60,8 +60,8 @@ void video_encoder::create_pipelines() {
     gst_caps_unref(caps_8uc1);
 
     // set bitrate from environment variables
-    // g_object_set(G_OBJECT(encoder_img0), "bitrate", std::stoi(std::getenv("ILLIXR_BITRATE")), nullptr, 10);
-    // g_object_set(G_OBJECT(encoder_img1), "bitrate", std::stoi(std::getenv("ILLIXR_BITRATE")), nullptr, 10);
+    // g_object_set(G_OBJECT(encoder_img0), "bitrate", std::stoi(sb->get_env("ILLIXR_BITRATE")), nullptr, 10);
+    // g_object_set(G_OBJECT(encoder_img1), "bitrate", std::stoi(sb->get_env("ILLIXR_BITRATE")), nullptr, 10);
 
     // set bitrate from defined variables
     g_object_set(G_OBJECT(encoder_img0), "bitrate", ILLIXR_BITRATE, nullptr);

--- a/plugins/offload_vio/server_rx/plugin.cpp
+++ b/plugins/offload_vio/server_rx/plugin.cpp
@@ -35,7 +35,7 @@ public:
         , server_ip(SERVER_IP)
         , server_port(SERVER_PORT_1)
         , buffer_str("") {
-        spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("OFFLOAD_VIO_LOG_LEVEL"));
         socket.socket_set_reuseaddr();
         socket.socket_bind(server_ip, server_port);
         socket.enable_no_delay();

--- a/plugins/offload_vio/server_tx/plugin.cpp
+++ b/plugins/offload_vio/server_tx/plugin.cpp
@@ -21,7 +21,7 @@ public:
         , _m_imu_int_input{sb->get_reader<imu_integrator_input>("imu_integrator_input")}
         , client_ip(CLIENT_IP)
         , client_port(CLIENT_PORT_2) {
-        spdlogger(std::getenv("OFFLOAD_VIO_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("OFFLOAD_VIO_LOG_LEVEL"));
         socket.socket_set_reuseaddr();
         socket.socket_bind(SERVER_IP, SERVER_PORT_2);
         socket.enable_no_delay();

--- a/plugins/openni/plugin.cpp
+++ b/plugins/openni/plugin.cpp
@@ -21,7 +21,7 @@ public:
         , sb{pb->lookup_impl<switchboard>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
         , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")} {
-        spdlogger(std::getenv("OPENNI_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("OPENNI_LOG_LEVEL"));
         if (!camera_initialize()) {
             spdlog::get(name)->error("Initialization failed");
             exit(0);

--- a/plugins/pose_lookup/data_loading.hpp
+++ b/plugins/pose_lookup/data_loading.hpp
@@ -2,6 +2,7 @@
 #include "illixr/csv_iterator.hpp"
 #include "illixr/data_format.hpp"
 #include "illixr/error_util.hpp"
+#include "illixr/switchboard.hpp"
 
 #include <eigen3/Eigen/Dense>
 #include <fstream>
@@ -21,12 +22,11 @@ using namespace ILLIXR;
 
 typedef pose_type sensor_types;
 
-static std::map<ullong, sensor_types> load_data() {
-    const char* illixr_data_c_str = std::getenv("ILLIXR_DATA");
-    if (!illixr_data_c_str) {
+static std::map<ullong, sensor_types> load_data(const std::shared_ptr<switchboard>& sb) {
+    const std::string illixr_data = sb->get_env("ILLIXR_DATA");
+    if (illixr_data.empty()) {
         ILLIXR::abort("Please define ILLIXR_DATA");
     }
-    std::string illixr_data = std::string{illixr_data_c_str};
 
     std::map<ullong, sensor_types> data;
 

--- a/plugins/pose_lookup/plugin.cpp
+++ b/plugins/pose_lookup/plugin.cpp
@@ -16,18 +16,18 @@ public:
     explicit pose_lookup_impl(const phonebook* const pb)
         : sb{pb->lookup_impl<switchboard>()}
         , _m_clock{pb->lookup_impl<RelativeClock>()}
-        , _m_sensor_data{load_data()}
+        , _m_sensor_data{load_data(sb)}
         , _m_sensor_data_it{_m_sensor_data.cbegin()}
         , dataset_first_time{_m_sensor_data_it->first}
         , _m_vsync_estimate{sb->get_reader<switchboard::event_wrapper<time_point>>("vsync_estimate")} /// TODO: Set with #198
-        , enable_alignment{ILLIXR::str_to_bool(getenv_or("ILLIXR_ALIGNMENT_ENABLE", "False"))}
+        , enable_alignment{sb->get_env_bool("ILLIXR_ALIGNMENT_ENABLE", "False")}
         , init_pos_offset{Eigen::Vector3f::Zero()}
         , align_rot{Eigen::Matrix3f::Zero()}
         , align_trans{Eigen::Vector3f::Zero()}
         , align_quat{Eigen::Vector4f::Zero()}
         , align_scale{0.0} {
         if (enable_alignment) {
-            std::string path_to_alignment(ILLIXR::getenv_or("ILLIXR_ALIGNMENT_FILE", "./metrics/alignMatrix.txt"));
+            std::string path_to_alignment(sb->get_env("ILLIXR_ALIGNMENT_FILE", "./metrics/alignMatrix.txt"));
             load_align_parameters(path_to_alignment, align_rot, align_trans, align_quat, align_scale);
         }
         // Read position data of the first frame

--- a/plugins/realsense/plugin.cpp
+++ b/plugins/realsense/plugin.cpp
@@ -37,8 +37,8 @@ public:
         , _m_imu{sb->get_writer<imu_type>("imu")}
         , _m_cam{sb->get_writer<cam_type>("cam")}
         , _m_rgb_depth{sb->get_writer<rgb_depth_type>("rgb_depth")}
-        , realsense_cam{ILLIXR::getenv_or("REALSENSE_CAM", "auto")} {
-        spdlogger(std::getenv("REALSENSE_LOG_LEVEL"));
+        , realsense_cam{sb->get_env("REALSENSE_CAM", "auto")} {
+        spdlogger(sb->get_env_char("REALSENSE_LOG_LEVEL"));
         accel_data.iteration = -1;
         cfg.disable_all_streams();
         configure_camera();

--- a/plugins/timewarp_gl/plugin.cpp
+++ b/plugins/timewarp_gl/plugin.cpp
@@ -77,14 +77,14 @@ public:
         // Timewarp poses a "second channel" by which pose data can correct the video stream,
         // which results in a "multipath" between the pose and the video stream.
         // In production systems, this is certainly a good thing, but it makes the system harder to analyze.
-        , disable_warp{ILLIXR::str_to_bool(ILLIXR::getenv_or("ILLIXR_TIMEWARP_DISABLE", "False"))}
-        , enable_offload{ILLIXR::str_to_bool(ILLIXR::getenv_or("ILLIXR_OFFLOAD_ENABLE", "False"))}
+        , disable_warp{ILLIXR::str_to_bool(sb->get_env("ILLIXR_TIMEWARP_DISABLE", "False"))}
+        , enable_offload{ILLIXR::str_to_bool(sb->get_env("ILLIXR_OFFLOAD_ENABLE", "False"))}
 #else
         , _m_signal_quad{sb->get_writer<signal_to_quad>("signal_quad")}
 #endif
         , timewarp_gpu_logger{record_logger_}
         , _m_hologram{sb->get_writer<hologram_input>("hologram_in")} {
-        spdlogger(std::getenv("TIMEWARP_GL_LOG_LEVEL"));
+        spdlogger(sb->get_env_char("TIMEWARP_GL_LOG_LEVEL"));
 #ifndef ILLIXR_MONADO
         const std::shared_ptr<xlib_gl_extended_window> xwin = pb->lookup_impl<xlib_gl_extended_window>();
         dpy                                                 = xwin->dpy;
@@ -519,7 +519,7 @@ public:
         glewExperimental      = GL_TRUE;
         const GLenum glew_err = glewInit();
         if (glew_err != GLEW_OK) {
-            spdlog::get(name)->error("[timewarp_gl] GLEW Error: {}", glewGetErrorString(glew_err));
+            spdlog::get(name)->error("[timewarp_gl] GLEW Error: {}", reinterpret_cast<const char*>(glewGetErrorString(glew_err)));
             ILLIXR::abort("[timewarp_gl] Failed to initialize GLEW");
         }
 

--- a/plugins/timewarp_vk/plugin.cpp
+++ b/plugins/timewarp_vk/plugin.cpp
@@ -79,7 +79,7 @@ public:
         : pb{pb}
         , sb{pb->lookup_impl<switchboard>()}
         , pp{pb->lookup_impl<pose_prediction>()}
-        , disable_warp{ILLIXR::str_to_bool(ILLIXR::getenv_or("ILLIXR_TIMEWARP_DISABLE", "False"))} { }
+        , disable_warp{sb->get_env_bool("ILLIXR_TIMEWARP_DISABLE", "False")} { }
 
     void initialize() {
         ds = pb->lookup_impl<display_sink>();

--- a/plugins/vkdemo/plugin.cpp
+++ b/plugins/vkdemo/plugin.cpp
@@ -578,8 +578,8 @@ private:
         std::vector<tinyobj::material_t> materials;
         std::string                      warn, err;
 
-        auto path = std::string(std::getenv("ILLIXR_DEMO_DATA")) + "/" + "scene.obj";
-        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str(), std::getenv("ILLIXR_DEMO_DATA"))) {
+        auto path = sb->get_env("ILLIXR_DEMO_DATA") + "/scene.obj";
+        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str(), sb->get_env_char("ILLIXR_DEMO_DATA"))) {
             throw std::runtime_error(warn + err);
         }
 
@@ -588,7 +588,7 @@ private:
         for (auto i = 0; i < static_cast<int>(materials.size()); i++) {
             auto material = materials[i];
             if (material.diffuse_texname.length() > 0) {
-                path = std::string(std::getenv("ILLIXR_DEMO_DATA")) + "/" + material.diffuse_texname;
+                path = sb->get_env("ILLIXR_DEMO_DATA") + "/" + material.diffuse_texname;
                 load_texture(path, i);
             }
         }

--- a/src/illixr.hpp
+++ b/src/illixr.hpp
@@ -11,9 +11,9 @@
 
 #define GET_STRING(NAME, ENV)                                         \
     if (options.count(#NAME)) {                                       \
-        setenv(#ENV, options[#NAME].as<std::string>().c_str(), true); \
+        sb->set_env(#ENV, options[#NAME].as<std::string>());          \
     } else if (config[#NAME]) {                                       \
-        setenv(#ENV, config[#NAME].as<std::string>().c_str(), true);  \
+        sb->set_env(#ENV, config[#NAME].as<std::string>());           \
     }
 
 #define GET_BOOL(NAME, ENV)                      \
@@ -25,18 +25,18 @@
             val = config[#NAME].as<bool>();      \
         }                                        \
         if (val) {                               \
-            setenv(#ENV, "True", true);          \
+            sb->set_env(#ENV, "True");           \
         } else {                                 \
-            setenv(#ENV, "False", false);        \
+            sb->set_env(#ENV, "False");          \
         }                                        \
     }
 #define _STR(y)      #y
 #define STRINGIZE(x) _STR(x)
 #define GET_LONG(NAME, ENV)                                                    \
     if (options.count(#NAME)) {                                                \
-        setenv(#ENV, std::to_string(options[#NAME].as<long>()).c_str(), true); \
+        sb->set_env(#ENV, std::to_string(options[#NAME].as<long>()));          \
     } else if (config[#NAME]) {                                                \
-        setenv(#ENV, std::to_string(config[#NAME].as<long>()).c_str(), true);  \
+        sb->set_env(#ENV, std::to_string(config[#NAME].as<long>()));            \
     }
 
 constexpr std::chrono::seconds          ILLIXR_RUN_DURATION_DEFAULT{60};

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,5 +1,6 @@
 #include "illixr.hpp"
 #include "illixr/error_util.hpp"
+#include "illixr/switchboard.hpp"
 
 #include <algorithm>
 #include <cstdlib>
@@ -17,11 +18,38 @@ int ILLIXR::run(const cxxopts::ParseResult& options) {
     std::vector<std::string> plugins;
 
     r = ILLIXR::runtime_factory();
+    // set internal env_vars
+    const std::shared_ptr<switchboard> sb = r->get_switchboard();
+
+    // read in yaml config file
+    YAML::Node config;
+    if (options.count("yaml")) {
+        std::cout << "Reading " << options["yaml"].as<std::string>() << std::endl;
+        config = YAML::LoadFile(options["yaml"].as<std::string>());
+    }
+
+    // set env vars from config file first, as command line args will override
+    for (auto& item: sb->env_names()){
+        if (config[item])
+            sb->set_env(item, config[item].as<std::string>());
+    }
+    // command line specified env_vars
+    for (auto& item : options.unmatched()) {
+        bool matched = false;
+        cxxopts::values::parser_tool::ArguDesc ad = cxxopts::values::parser_tool::ParseArgument(item.c_str(), matched);
+
+        if (!sb->get_env(ad.arg_name, "").empty()) {
+            if (!ad.set_value)
+                ad.value = "True";
+            sb->set_env(ad.arg_name, ad.value);
+            setenv(ad.arg_name.c_str(), ad.value.c_str(), 1);  // env vars from command line take precedence
+        }
+    }
 
 #ifndef NDEBUG
     /// Activate sleeping at application start for attaching gdb. Disables 'catchsegv'.
     /// Enable using the ILLIXR_ENABLE_PRE_SLEEP environment variable (see 'runner/runner/main.py:load_tests')
-    const bool enable_pre_sleep = ILLIXR::str_to_bool(getenv_or("ILLIXR_ENABLE_PRE_SLEEP", "False"));
+    const bool enable_pre_sleep = sb->get_env_bool("ILLIXR_ENABLE_PRE_SLEEP", "False");
     if (enable_pre_sleep) {
         const pid_t pid = getpid();
         spdlog::get("illixr")->info("[main] Pre-sleep enabled.");
@@ -31,19 +59,14 @@ int ILLIXR::run(const cxxopts::ParseResult& options) {
         spdlog::get("illixr")->info("[main] Resuming...");
     }
 #endif /// NDEBUG
-    // read in yaml config file
-    YAML::Node config;
-    if (options.count("yaml")) {
-        std::cout << "Reading " << options["yaml"].as<std::string>() << std::endl;
-        config = YAML::LoadFile(options["yaml"].as<std::string>());
-    }
+
     if (options.count("duration")) {
         run_duration = std::chrono::seconds{options["duration"].as<long>()};
     } else if (config["duration"]) {
         run_duration = std::chrono::seconds{config["duration"].as<long>()};
     } else {
-        run_duration = getenv("ILLIXR_RUN_DURATION")
-            ? std::chrono::seconds{std::stol(std::string{getenv("ILLIXR_RUN_DURATION")})}
+        run_duration = (!sb->get_env("ILLIXR_RUN_DURATION").empty())
+            ? std::chrono::seconds{std::stol(std::string{sb->get_env("ILLIXR_RUN_DURATION")})}
             : ILLIXR_RUN_DURATION_DEFAULT;
     }
     GET_STRING(data, ILLIXR_DATA)
@@ -93,7 +116,7 @@ int ILLIXR::run(const cxxopts::ParseResult& options) {
         plugins.push_back(visualizers[0]);
 
     if (config["install_prefix"]) {
-        std::string temp_path(getenv("LD_LIBRARY_PATH"));
+        std::string temp_path(sb->get_env("LD_LIBRARY_PATH"));
         temp_path = config["install_prefix"].as<std::string>() + ":" + temp_path;
         setenv("LD_LIBRARY_PATH", temp_path.c_str(), true);
     }

--- a/src/runtime_impl.cpp
+++ b/src/runtime_impl.cpp
@@ -41,7 +41,7 @@ void spdlogger(const std::string& name, const char* log_level) {
 class runtime_impl : public runtime {
 public:
     explicit runtime_impl() {
-        spdlogger("illixr", std::getenv("ILLIXR_LOG_LEVEL"));
+        spdlogger("illixr", std::getenv("ILLIXR_LOG_LEVEL"));  // can't use switchboard interface here
         pb.register_impl<record_logger>(std::make_shared<sqlite_record_logger>());
         pb.register_impl<gen_guid>(std::make_shared<gen_guid>());
         pb.register_impl<switchboard>(std::make_shared<switchboard>(&pb));
@@ -141,6 +141,9 @@ public:
          */
     }
 
+    std::shared_ptr<switchboard> get_switchboard() override {
+        return pb.lookup_impl<switchboard>();
+    }
 private:
     // I have to keep the dynamic libs in scope until the program is dead
     std::vector<dynamic_lib>             libs;


### PR DESCRIPTION
This PR moves the environment variable handling to the switchbaord. This allows for env vars to be defined on the command line and yaml files, in addition to the traditional method. The switchboard keeps an internal listing of all known env vars for quick lookup.

It provides the following functions:
get_env (returns std::string)
get_env_bool (returns a bool based on the value of the environment variable)
get_env_char (returns a char* like the system version)
set_env (sets both internal map and system level env var)

All of the get methods also take an optional default argument if the env var is not defined.

Note that the traditional getenv and setenv will still work, and are still used in a few places where the switchboard is not in scope.