### PR TITLE
Fix thread join in display_vk plugin stop method

### DIFF
--- a/plugins/display_vk/plugin.cpp
+++ b/plugins/display_vk/plugin.cpp
@@ -155,6 +155,9 @@ void display_vk_plugin::start() {
 
 void display_vk_plugin::stop() {
     running_ = false;
+    if (main_thread_.joinable()) {
+        main_thread_.join();
+    }
 }
 
 void display_vk_plugin::main_loop() {


### PR DESCRIPTION
Ensure proper thread cleanup by joining the main thread if it is joinable when stopping the display_vk plugin.